### PR TITLE
Change paraId for development & local

### DIFF
--- a/node/src/chain_spec/crab.rs
+++ b/node/src/chain_spec/crab.rs
@@ -78,7 +78,7 @@ pub fn development_config() -> ChainSpec {
 					array_bytes::hex_n_into_unchecked(ETHAN),
 					array_bytes::hex_n_into_unchecked(FAITH),
 				],
-				1000.into(),
+				2105.into(),
 			)
 		},
 		Vec::new(),
@@ -88,7 +88,7 @@ pub fn development_config() -> ChainSpec {
 		Some(properties),
 		Extensions {
 			relay_chain: "rococo-local".into(), // You MUST set this to the correct network!
-			para_id: 1000,
+			para_id: 2105,
 		},
 	)
 }
@@ -129,7 +129,7 @@ pub fn local_testnet_config() -> ChainSpec {
 					array_bytes::hex_n_into_unchecked(ETHAN),
 					array_bytes::hex_n_into_unchecked(FAITH),
 				],
-				1000.into(),
+				2105.into(),
 			)
 		},
 		// Bootnodes
@@ -145,7 +145,7 @@ pub fn local_testnet_config() -> ChainSpec {
 		// Extensions
 		Extensions {
 			relay_chain: "rococo-local".into(), // You MUST set this to the correct network!
-			para_id: 1000,
+			para_id: 2105,
 		},
 	)
 }

--- a/node/src/chain_spec/darwinia.rs
+++ b/node/src/chain_spec/darwinia.rs
@@ -78,7 +78,7 @@ pub fn development_config() -> ChainSpec {
 					array_bytes::hex_n_into_unchecked(ETHAN),
 					array_bytes::hex_n_into_unchecked(FAITH),
 				],
-				1000.into(),
+				2105.into(),
 			)
 		},
 		Vec::new(),
@@ -88,7 +88,7 @@ pub fn development_config() -> ChainSpec {
 		Some(properties),
 		Extensions {
 			relay_chain: "rococo-local".into(), // You MUST set this to the correct network!
-			para_id: 1000,
+			para_id: 2105,
 		},
 	)
 }
@@ -129,7 +129,7 @@ pub fn local_testnet_config() -> ChainSpec {
 					array_bytes::hex_n_into_unchecked(ETHAN),
 					array_bytes::hex_n_into_unchecked(FAITH),
 				],
-				1000.into(),
+				2105.into(),
 			)
 		},
 		// Bootnodes
@@ -145,7 +145,7 @@ pub fn local_testnet_config() -> ChainSpec {
 		// Extensions
 		Extensions {
 			relay_chain: "rococo-local".into(), // You MUST set this to the correct network!
-			para_id: 1000,
+			para_id: 2105,
 		},
 	)
 }

--- a/node/src/chain_spec/darwinia.rs
+++ b/node/src/chain_spec/darwinia.rs
@@ -78,7 +78,7 @@ pub fn development_config() -> ChainSpec {
 					array_bytes::hex_n_into_unchecked(ETHAN),
 					array_bytes::hex_n_into_unchecked(FAITH),
 				],
-				2105.into(),
+				2046.into(),
 			)
 		},
 		Vec::new(),
@@ -88,7 +88,7 @@ pub fn development_config() -> ChainSpec {
 		Some(properties),
 		Extensions {
 			relay_chain: "rococo-local".into(), // You MUST set this to the correct network!
-			para_id: 2105,
+			para_id: 2046,
 		},
 	)
 }
@@ -129,7 +129,7 @@ pub fn local_testnet_config() -> ChainSpec {
 					array_bytes::hex_n_into_unchecked(ETHAN),
 					array_bytes::hex_n_into_unchecked(FAITH),
 				],
-				2105.into(),
+				2046.into(),
 			)
 		},
 		// Bootnodes
@@ -145,7 +145,7 @@ pub fn local_testnet_config() -> ChainSpec {
 		// Extensions
 		Extensions {
 			relay_chain: "rococo-local".into(), // You MUST set this to the correct network!
-			para_id: 2105,
+			para_id: 2046,
 		},
 	)
 }

--- a/node/src/chain_spec/pangolin.rs
+++ b/node/src/chain_spec/pangolin.rs
@@ -78,7 +78,7 @@ pub fn development_config() -> ChainSpec {
 					array_bytes::hex_n_into_unchecked(ETHAN),
 					array_bytes::hex_n_into_unchecked(FAITH),
 				],
-				1000.into(),
+				2105.into(),
 			)
 		},
 		Vec::new(),
@@ -88,7 +88,7 @@ pub fn development_config() -> ChainSpec {
 		Some(properties),
 		Extensions {
 			relay_chain: "rococo-local".into(), // You MUST set this to the correct network!
-			para_id: 1000,
+			para_id: 2105,
 		},
 	)
 }
@@ -129,7 +129,7 @@ pub fn local_testnet_config() -> ChainSpec {
 					array_bytes::hex_n_into_unchecked(ETHAN),
 					array_bytes::hex_n_into_unchecked(FAITH),
 				],
-				1000.into(),
+				2105.into(),
 			)
 		},
 		// Bootnodes
@@ -145,7 +145,7 @@ pub fn local_testnet_config() -> ChainSpec {
 		// Extensions
 		Extensions {
 			relay_chain: "rococo-local".into(), // You MUST set this to the correct network!
-			para_id: 1000,
+			para_id: 2105,
 		},
 	)
 }


### PR DESCRIPTION
ParaId 1000 is very easy to conflict with other parachain development configurations (like moonbase), resulting in the need to build spec and modify paraId when testing with other parachains, which is a bit cumbersome. So I modified it in genesis config.