### PR TITLE
Improve config for pallet_bridge_grandpa

### DIFF
--- a/runtime/crab/src/pallets/bridge_grandpa.rs
+++ b/runtime/crab/src/pallets/bridge_grandpa.rs
@@ -26,8 +26,8 @@ pub type PolkadotHeadersToKeep = ConstU32<500>;
 impl pallet_bridge_grandpa::Config<WithPolkadotGrandpa> for Runtime {
 	type BridgedChain = bp_darwinia::DarwiniaLike;
 	type HeadersToKeep = PolkadotHeadersToKeep;
-	type MaxBridgedAuthorities = frame_support::traits::ConstU32<100_000>;
-	type MaxBridgedHeaderSize = frame_support::traits::ConstU32<65536>;
+	type MaxBridgedAuthorities = ConstU32<100_000>;
+	type MaxBridgedHeaderSize = ConstU32<65536>;
 	type MaxRequests = ConstU32<50>;
 	type WeightInfo = ();
 }

--- a/runtime/crab/src/pallets/bridge_grandpa.rs
+++ b/runtime/crab/src/pallets/bridge_grandpa.rs
@@ -26,7 +26,7 @@ pub type PolkadotHeadersToKeep = ConstU32<500>;
 impl pallet_bridge_grandpa::Config<WithPolkadotGrandpa> for Runtime {
 	type BridgedChain = bp_darwinia::DarwiniaLike;
 	type HeadersToKeep = PolkadotHeadersToKeep;
-	type MaxBridgedAuthorities = ();
+	type MaxBridgedAuthorities = frame_support::traits::ConstU32<100_000>;
 	type MaxBridgedHeaderSize = ();
 	type MaxRequests = ConstU32<50>;
 	type WeightInfo = ();

--- a/runtime/crab/src/pallets/bridge_grandpa.rs
+++ b/runtime/crab/src/pallets/bridge_grandpa.rs
@@ -29,5 +29,5 @@ impl pallet_bridge_grandpa::Config<WithPolkadotGrandpa> for Runtime {
 	type MaxBridgedAuthorities = frame_support::traits::ConstU32<100_000>;
 	type MaxBridgedHeaderSize = frame_support::traits::ConstU32<65536>;
 	type MaxRequests = ConstU32<50>;
-	type WeightInfo = ();
+	type WeightInfo = pallet_bridge_grandpa::weights::BridgeWeight<Runtime>;
 }

--- a/runtime/crab/src/pallets/bridge_grandpa.rs
+++ b/runtime/crab/src/pallets/bridge_grandpa.rs
@@ -27,7 +27,7 @@ impl pallet_bridge_grandpa::Config<WithPolkadotGrandpa> for Runtime {
 	type BridgedChain = bp_darwinia::DarwiniaLike;
 	type HeadersToKeep = PolkadotHeadersToKeep;
 	type MaxBridgedAuthorities = frame_support::traits::ConstU32<100_000>;
-	type MaxBridgedHeaderSize = ();
+	type MaxBridgedHeaderSize = frame_support::traits::ConstU32<65536>;
 	type MaxRequests = ConstU32<50>;
 	type WeightInfo = ();
 }

--- a/runtime/crab/src/pallets/bridge_grandpa.rs
+++ b/runtime/crab/src/pallets/bridge_grandpa.rs
@@ -29,5 +29,5 @@ impl pallet_bridge_grandpa::Config<WithPolkadotGrandpa> for Runtime {
 	type MaxBridgedAuthorities = frame_support::traits::ConstU32<100_000>;
 	type MaxBridgedHeaderSize = frame_support::traits::ConstU32<65536>;
 	type MaxRequests = ConstU32<50>;
-	type WeightInfo = pallet_bridge_grandpa::weights::BridgeWeight<Runtime>;
+	type WeightInfo = ();
 }

--- a/runtime/darwinia/src/pallets/bridge_grandpa.rs
+++ b/runtime/darwinia/src/pallets/bridge_grandpa.rs
@@ -26,7 +26,7 @@ pub type KusamaHeadersToKeep = ConstU32<500>;
 impl pallet_bridge_grandpa::Config<WithKusamaGrandpa> for Runtime {
 	type BridgedChain = bp_crab::DarwiniaLike;
 	type HeadersToKeep = KusamaHeadersToKeep;
-	type MaxBridgedAuthorities = ();
+	type MaxBridgedAuthorities = frame_support::traits::ConstU32<100_000>;
 	type MaxBridgedHeaderSize = ();
 	type MaxRequests = ConstU32<50>;
 	type WeightInfo = ();

--- a/runtime/darwinia/src/pallets/bridge_grandpa.rs
+++ b/runtime/darwinia/src/pallets/bridge_grandpa.rs
@@ -29,5 +29,5 @@ impl pallet_bridge_grandpa::Config<WithKusamaGrandpa> for Runtime {
 	type MaxBridgedAuthorities = frame_support::traits::ConstU32<100_000>;
 	type MaxBridgedHeaderSize = frame_support::traits::ConstU32<65536>;
 	type MaxRequests = ConstU32<50>;
-	type WeightInfo = pallet_bridge_grandpa::weights::BridgeWeight<Runtime>;
+	type WeightInfo = ();
 }

--- a/runtime/darwinia/src/pallets/bridge_grandpa.rs
+++ b/runtime/darwinia/src/pallets/bridge_grandpa.rs
@@ -29,5 +29,5 @@ impl pallet_bridge_grandpa::Config<WithKusamaGrandpa> for Runtime {
 	type MaxBridgedAuthorities = frame_support::traits::ConstU32<100_000>;
 	type MaxBridgedHeaderSize = frame_support::traits::ConstU32<65536>;
 	type MaxRequests = ConstU32<50>;
-	type WeightInfo = ();
+	type WeightInfo = pallet_bridge_grandpa::weights::BridgeWeight<Runtime>;
 }

--- a/runtime/darwinia/src/pallets/bridge_grandpa.rs
+++ b/runtime/darwinia/src/pallets/bridge_grandpa.rs
@@ -27,7 +27,7 @@ impl pallet_bridge_grandpa::Config<WithKusamaGrandpa> for Runtime {
 	type BridgedChain = bp_crab::DarwiniaLike;
 	type HeadersToKeep = KusamaHeadersToKeep;
 	type MaxBridgedAuthorities = frame_support::traits::ConstU32<100_000>;
-	type MaxBridgedHeaderSize = ();
+	type MaxBridgedHeaderSize = frame_support::traits::ConstU32<65536>;
 	type MaxRequests = ConstU32<50>;
 	type WeightInfo = ();
 }

--- a/runtime/darwinia/src/pallets/bridge_grandpa.rs
+++ b/runtime/darwinia/src/pallets/bridge_grandpa.rs
@@ -26,8 +26,8 @@ pub type KusamaHeadersToKeep = ConstU32<500>;
 impl pallet_bridge_grandpa::Config<WithKusamaGrandpa> for Runtime {
 	type BridgedChain = bp_crab::DarwiniaLike;
 	type HeadersToKeep = KusamaHeadersToKeep;
-	type MaxBridgedAuthorities = frame_support::traits::ConstU32<100_000>;
-	type MaxBridgedHeaderSize = frame_support::traits::ConstU32<65536>;
+	type MaxBridgedAuthorities = ConstU32<100_000>;
+	type MaxBridgedHeaderSize = ConstU32<65536>;
 	type MaxRequests = ConstU32<50>;
 	type WeightInfo = ();
 }


### PR DESCRIPTION
Changed:

## MaxBridgedAuthorities
`()` -> `frame_support::traits::ConstU32<100_000>`

https://github.com/darwinia-network/darwinia-messages-substrate/blob/dd55c3dbc30f54e93fc231e9161a810153a8c266/modules/grandpa/src/storage_types.rs#L36

https://github.com/paritytech/substrate/blob/a3ed0119c45cdd0d571ad34e5b3ee7518c8cef8d/primitives/core/src/bounded/bounded_vec.rs#L678

we should set this, the value `100_000` is reference rococo. https://github.com/paritytech/parity-bridges-common/blob/c28b3ff66c29c6c9d9955583b50c2114de14e98c/primitives/chain-rococo/src/lib.rs#L45-L48

## MaxBridgedHeaderSize

`()` -> `frame_support::traits::ConstU32<65536>`

the parity-bridges-common does not have this filed now (for main branch). just have `MaxParaHeadDataSize` for parachains pallet. https://github.com/paritytech/parity-bridges-common/blob/c28b3ff66c29c6c9d9955583b50c2114de14e98c/bin/millau/runtime/src/lib.rs#L540
But what is certain is that this field means to limit the maximum size of the submitted header.
https://github.com/darwinia-network/darwinia-messages-substrate/blob/dd55c3dbc30f54e93fc231e9161a810153a8c266/modules/grandpa/src/lib.rs#L118-L126
https://github.com/darwinia-network/darwinia-messages-substrate/blob/dd55c3dbc30f54e93fc231e9161a810153a8c266/primitives/runtime/src/storage_types.rs#L51-L62

## ~~WeightInfo~~

~~`()` -> `pallet_bridge_grandpa::weights::BridgeWeight<Runtime>`~~

~~Reference https://github.com/paritytech/parity-bridges-common/blob/c28b3ff66c29c6c9d9955583b50c2114de14e98c/bin/millau/runtime/src/lib.rs#L431~~

