### PR TITLE
Fix new added precompiles code

### DIFF
--- a/node/src/chain_spec/crab.rs
+++ b/node/src/chain_spec/crab.rs
@@ -199,7 +199,23 @@ pub fn genesis_config() -> ChainSpec {
 
 				// EVM stuff.
 				ethereum: Default::default(),
-				evm: Default::default(),
+				evm: EvmConfig {
+					accounts: {
+						BTreeMap::from_iter(
+							CrabPrecompiles::<Runtime>::used_addresses().iter().map(|p| {
+								(
+									p.to_owned(),
+									GenesisAccount {
+										nonce: Default::default(),
+										balance: Default::default(),
+										storage: Default::default(),
+										code: REVERT_BYTECODE.to_vec(),
+									},
+								)
+							}),
+						)
+					},
+				},
 				base_fee: Default::default(),
 
 				// S2S stuff.
@@ -310,17 +326,6 @@ fn testnet_genesis(
 							)
 						})
 						.chain([
-							// Testing account.
-							(
-								H160::from_str("0x6be02d1d3665660d22ff9624b7be0551ee1ac91b")
-									.unwrap(),
-								GenesisAccount {
-									balance: (10_000_000 * UNIT).into(),
-									code: Default::default(),
-									nonce: Default::default(),
-									storage: Default::default(),
-								},
-							),
 							// Benchmarking account.
 							(
 								H160::from_str("1000000000000000000000000000000000000001").unwrap(),

--- a/node/src/chain_spec/darwinia.rs
+++ b/node/src/chain_spec/darwinia.rs
@@ -199,7 +199,23 @@ pub fn genesis_config() -> ChainSpec {
 
 				// EVM stuff.
 				ethereum: Default::default(),
-				evm: Default::default(),
+				evm: EvmConfig {
+					accounts: {
+						BTreeMap::from_iter(
+							DarwiniaPrecompiles::<Runtime>::used_addresses().iter().map(|p| {
+								(
+									p.to_owned(),
+									GenesisAccount {
+										nonce: Default::default(),
+										balance: Default::default(),
+										storage: Default::default(),
+										code: REVERT_BYTECODE.to_vec(),
+									},
+								)
+							}),
+						)
+					},
+				},
 				base_fee: Default::default(),
 
 				// S2S stuff.
@@ -310,17 +326,6 @@ fn testnet_genesis(
 							)
 						})
 						.chain([
-							// Testing account.
-							(
-								H160::from_str("0x6be02d1d3665660d22ff9624b7be0551ee1ac91b")
-									.unwrap(),
-								GenesisAccount {
-									balance: (10_000_000 * UNIT).into(),
-									code: Default::default(),
-									nonce: Default::default(),
-									storage: Default::default(),
-								},
-							),
 							// Benchmarking account.
 							(
 								H160::from_str("1000000000000000000000000000000000000001").unwrap(),

--- a/node/src/chain_spec/pangolin.rs
+++ b/node/src/chain_spec/pangolin.rs
@@ -199,7 +199,23 @@ pub fn genesis_config() -> ChainSpec {
 
 				// EVM stuff.
 				ethereum: Default::default(),
-				evm: Default::default(),
+				evm: EvmConfig {
+					accounts: {
+						BTreeMap::from_iter(
+							PangolinPrecompiles::<Runtime>::used_addresses().iter().map(|p| {
+								(
+									p.to_owned(),
+									GenesisAccount {
+										nonce: Default::default(),
+										balance: Default::default(),
+										storage: Default::default(),
+										code: REVERT_BYTECODE.to_vec(),
+									},
+								)
+							}),
+						)
+					},
+				},
 				base_fee: Default::default(),
 			}
 		},
@@ -304,17 +320,6 @@ fn testnet_genesis(
 							)
 						})
 						.chain([
-							// Testing account.
-							(
-								H160::from_str("0x6be02d1d3665660d22ff9624b7be0551ee1ac91b")
-									.unwrap(),
-								GenesisAccount {
-									balance: (10_000_000 * UNIT).into(),
-									code: Default::default(),
-									nonce: Default::default(),
-									storage: Default::default(),
-								},
-							),
 							// Benchmarking account.
 							(
 								H160::from_str("1000000000000000000000000000000000000001").unwrap(),

--- a/runtime/common/src/test.rs
+++ b/runtime/common/src/test.rs
@@ -205,10 +205,7 @@ macro_rules! impl_account_migration_tests {
 
 					assert_ok!(migrate(from, to));
 					assert_eq!(AccountMigration::kton_account_of(from_pk), None);
-					assert_eq!(
-						Assets::maybe_balance(KTON_ID, to).unwrap(),
-						KTON_AMOUNT
-					);
+					assert_eq!(Assets::maybe_balance(KTON_ID, to).unwrap(), KTON_AMOUNT);
 				});
 			}
 

--- a/tool/state-processor/src/tests.rs
+++ b/tool/state-processor/src/tests.rs
@@ -339,7 +339,21 @@ fn evm_code_migrate() {
 		}
 
 		{
-			assert_eq!(tester.solo_evm_codes, tester.shell_evm_codes);
+			tester.solo_evm_codes.iter().for_each(|(k, v)| {
+				assert_eq!(tester.shell_evm_codes.get(k), Some(v));
+			});
+		}
+	});
+}
+
+#[test]
+fn precompiles_code_should_work() {
+	run_test(|tester| {
+		let addrs = ["001", "009", "400", "402", "600", "601"];
+
+		for i in addrs {
+			let addr = format!("{}{i}", "0x0000000000000000000000000000000000000");
+			assert_eq!(tester.shell_evm_codes.get(&addr), Some(&[96, 0, 96, 0, 253].to_vec()));
 		}
 	});
 }


### PR DESCRIPTION
The darwinia 2.0 adds some new precompiles like `deposit`, `kton`, `staking`, which the darwinia 1.0 doesn't have.

During the evm state process, we move the original code directly, those newly added precompiles codes are missing.


I find the following logs when running the state processor based on the changes:

![image](https://user-images.githubusercontent.com/11801722/212280112-b51218e3-b70b-4d62-9aa4-56fb7299d35a.png)

Since the overlapping precompile accounts also exist in the darwinia 1.0 evm code storage, these accounts will overrides the state generated from genesis. Does this error message need to fix? @AurevoirXavier 