### PR TITLE
Add missing field

### DIFF
--- a/tool/state-processor/src/staking/mod.rs
+++ b/tool/state-processor/src/staking/mod.rs
@@ -49,6 +49,7 @@ impl<S> Processor<S> {
 								Deposit {
 									id,
 									value: d.value,
+									start_time: d.start_time as _,
 									expired_time: d.expire_time as _,
 									in_use: true,
 								}

--- a/tool/state-processor/src/type_registry.rs
+++ b/tool/state-processor/src/type_registry.rs
@@ -112,6 +112,7 @@ pub struct VestingInfo {
 pub struct Deposit {
 	pub id: u16,
 	pub value: u128,
+	pub start_time: u128,
 	pub expired_time: u128,
 	pub in_use: bool,
 }


### PR DESCRIPTION
This mistake broke the runtime storage.

We need more tests for the state processor.