### PR TITLE
Clean imports

### DIFF
--- a/pallet/message-transact/src/mock.rs
+++ b/pallet/message-transact/src/mock.rs
@@ -27,10 +27,8 @@ use pallet_ethereum::IntermediateStateRoot;
 use frame_support::{
 	dispatch::RawOrigin,
 	ensure,
-	pallet_prelude::Weight,
 	traits::{ConstU32, Everything},
 };
-use sp_core::{H256, U256};
 use sp_runtime::{
 	testing::Header,
 	traits::{BlakeTwo256, DispatchInfoOf, IdentifyAccount, IdentityLookup, Verify},
@@ -43,7 +41,7 @@ use bp_message_dispatch::{CallValidate, IntoDispatchOrigin as IntoDispatchOrigin
 
 pub type Block = frame_system::mocking::MockBlock<TestRuntime>;
 pub type Balance = u64;
-pub type AccountId = H160;
+pub type AccountId = sp_core::H160;
 pub type UncheckedExtrinsic = frame_system::mocking::MockUncheckedExtrinsic<TestRuntime>;
 
 frame_support::parameter_types! {
@@ -58,7 +56,7 @@ impl frame_system::Config for TestRuntime {
 	type BlockNumber = u64;
 	type BlockWeights = ();
 	type DbWeight = ();
-	type Hash = H256;
+	type Hash = sp_core::H256;
 	type Hashing = BlakeTwo256;
 	type Header = Header;
 	type Index = u64;
@@ -105,14 +103,14 @@ impl pallet_timestamp::Config for TestRuntime {
 frame_support::parameter_types! {
 	pub const TransactionByteFee: u64 = 1;
 	pub const ChainId: u64 = 42;
-	pub const BlockGasLimit: U256 = U256::MAX;
-	pub const WeightPerGas: Weight = Weight::from_ref_time(20_000);
+	pub const BlockGasLimit: sp_core::U256 = sp_core::U256::MAX;
+	pub const WeightPerGas: frame_support::weights::Weight = frame_support::weights::Weight::from_ref_time(20_000);
 }
 
 pub struct FixedGasPrice;
 impl FeeCalculator for FixedGasPrice {
-	fn min_gas_price() -> (U256, Weight) {
-		(U256::from(5), Weight::zero())
+	fn min_gas_price() -> (sp_core::U256, frame_support::weights::Weight) {
+		(sp_core::U256::from(5), frame_support::weights::Weight::zero())
 	}
 }
 
@@ -141,8 +139,8 @@ impl pallet_ethereum::Config for TestRuntime {
 }
 
 pub struct MockAccountIdConverter;
-impl sp_runtime::traits::Convert<H256, AccountId> for MockAccountIdConverter {
-	fn convert(hash: H256) -> AccountId {
+impl sp_runtime::traits::Convert<sp_core::H256, AccountId> for MockAccountIdConverter {
+	fn convert(hash: sp_core::H256) -> AccountId {
 		hash.into()
 	}
 }
@@ -266,7 +264,7 @@ frame_support::construct_runtime! {
 }
 
 impl fp_self_contained::SelfContainedCall for RuntimeCall {
-	type SignedInfo = H160;
+	type SignedInfo = sp_core::H160;
 
 	fn is_self_contained(&self) -> bool {
 		match self {
@@ -323,8 +321,8 @@ impl fp_self_contained::SelfContainedCall for RuntimeCall {
 }
 
 pub(crate) struct AccountInfo {
-	pub address: H160,
-	pub private_key: H256,
+	pub address: sp_core::H160,
+	pub private_key: sp_core::H256,
 }
 
 pub(crate) fn address_build(seed: u8) -> AccountInfo {

--- a/pallet/message-transact/src/tests/mod.rs
+++ b/pallet/message-transact/src/tests/mod.rs
@@ -32,14 +32,13 @@ use crate::mock::*;
 use bp_message_dispatch::{CallOrigin, MessageDispatch, MessagePayload, SpecVersion};
 use bp_runtime::messages::DispatchFeePayment;
 // substrate
-use frame_support::pallet_prelude::Weight;
 use sp_core::{H256, U256};
 
 pub(crate) const TEST_SPEC_VERSION: SpecVersion = 0;
 pub(crate) type SubChainId = [u8; 4];
 pub(crate) const SOURCE_CHAIN_ID: SubChainId = *b"srce";
 pub(crate) const TARGET_CHAIN_ID: SubChainId = *b"trgt";
-pub(crate) const TEST_WEIGHT: Weight = Weight::from_ref_time(1_000_000_000_000);
+pub(crate) const TEST_WEIGHT: frame_support::weights::Weight = frame_support::weights::Weight::from_ref_time(1_000_000_000_000);
 
 // This ERC-20 contract mints the maximum amount of tokens to the contract creator.
 // pragma solidity ^0.5.0;

--- a/precompile/assets/src/mock.rs
+++ b/precompile/assets/src/mock.rs
@@ -21,7 +21,6 @@ use codec::{Decode, Encode, MaxEncodedLen};
 // frontier
 use fp_evm::{Precompile, PrecompileSet};
 // parity
-use frame_support::pallet_prelude::Weight;
 use sp_core::{H160, H256, U256};
 use sp_std::{marker::PhantomData, prelude::*};
 // darwinia
@@ -148,7 +147,7 @@ impl AccountToAssetId<AccountId, AssetId> for AssetIdConverter {
 
 frame_support::parameter_types! {
 	pub const BlockGasLimit: U256 = U256::MAX;
-	pub const WeightPerGas: Weight = Weight::from_ref_time(20_000);
+	pub const WeightPerGas: frame_support::weights::Weight = frame_support::weights::Weight::from_ref_time(20_000);
 	pub PrecompilesValue: TestPrecompiles<TestRuntime> = TestPrecompiles::<_>::new();
 }
 

--- a/precompile/deposit/src/mock.rs
+++ b/precompile/deposit/src/mock.rs
@@ -23,7 +23,6 @@ use crate::*;
 // frontier
 use fp_evm::{Precompile, PrecompileSet};
 // substrate
-use frame_support::pallet_prelude::Weight;
 use sp_core::{ConstU32, H160, H256, U256};
 
 pub(crate) type Balance = u128;
@@ -150,7 +149,7 @@ fn addr(a: u64) -> H160 {
 
 frame_support::parameter_types! {
 	pub const BlockGasLimit: U256 = U256::MAX;
-	pub const WeightPerGas: Weight = Weight::from_ref_time(20_000);
+	pub const WeightPerGas: frame_support::weights::Weight = frame_support::weights::Weight::from_ref_time(20_000);
 	pub PrecompilesValue: TestPrecompiles<TestRuntime> = TestPrecompiles::<_>::new();
 }
 

--- a/precompile/staking/src/mock.rs
+++ b/precompile/staking/src/mock.rs
@@ -23,7 +23,6 @@ use crate::*;
 // frontier
 use fp_evm::{Precompile, PrecompileSet};
 // substrate
-use frame_support::pallet_prelude::Weight;
 use sp_core::{ConstU32, H160, H256, U256};
 
 pub(crate) type Balance = u128;
@@ -154,7 +153,7 @@ pub type PCall = StakingCall<TestRuntime>;
 
 frame_support::parameter_types! {
 	pub const BlockGasLimit: U256 = U256::MAX;
-	pub const WeightPerGas: Weight = Weight::from_ref_time(20_000);
+	pub const WeightPerGas: frame_support::weights::Weight = frame_support::weights::Weight::from_ref_time(20_000);
 	pub PrecompilesValue: TestPrecompiles<TestRuntime> = TestPrecompiles::<_>::new();
 }
 

--- a/precompile/state-storage/src/mock.rs
+++ b/precompile/state-storage/src/mock.rs
@@ -21,7 +21,7 @@ use codec::{Decode, Encode, MaxEncodedLen};
 // frontier
 use fp_evm::{Precompile, PrecompileSet};
 // substrate
-use frame_support::{pallet_prelude::Weight, StorageHasher, Twox128};
+use frame_support::{StorageHasher, Twox128};
 use sp_core::{H160, H256, U256};
 use sp_std::{marker::PhantomData, prelude::*};
 // darwinia
@@ -134,7 +134,7 @@ fn addr(a: u64) -> H160 {
 
 frame_support::parameter_types! {
 	pub const BlockGasLimit: U256 = U256::MAX;
-	pub const WeightPerGas: Weight = Weight::from_ref_time(20_000);
+	pub const WeightPerGas: frame_support::weights::Weight = frame_support::weights::Weight::from_ref_time(20_000);
 	pub PrecompilesValue: TestPrecompiles<TestRuntime> = TestPrecompiles::<_>::new();
 }
 

--- a/runtime/common/src/lib.rs
+++ b/runtime/common/src/lib.rs
@@ -91,7 +91,7 @@ pub const fn darwinia_deposit(items: u32, bytes: u32) -> Balance {
 macro_rules! impl_self_contained_call {
 	() => {
 		impl fp_self_contained::SelfContainedCall for RuntimeCall {
-			type SignedInfo = H160;
+			type SignedInfo = sp_core::H160;
 
 			fn is_self_contained(&self) -> bool {
 				match self {
@@ -119,7 +119,7 @@ macro_rules! impl_self_contained_call {
 				info: &Self::SignedInfo,
 				dispatch_info: &sp_runtime::traits::DispatchInfoOf<RuntimeCall>,
 				len: usize,
-			) -> Option<TransactionValidity> {
+			) -> Option<sp_runtime::transaction_validity::TransactionValidity> {
 				match self {
 					RuntimeCall::Ethereum(call) =>
 						call.validate_self_contained(info, dispatch_info, len),

--- a/runtime/crab/src/lib.rs
+++ b/runtime/crab/src/lib.rs
@@ -647,13 +647,11 @@ cumulus_pallet_parachain_system::register_validate_block! {
 #[cfg(test)]
 mod tests {
 	// darwinia
-	use super::{Runtime, WeightPerGas};
-	// substrate
-	use frame_support::dispatch::DispatchClass;
+	use super::*;
 
 	#[test]
 	fn configured_base_extrinsic_weight_is_evm_compatible() {
-		let min_ethereum_transaction_weight = frame_support::weights::WeightPerGas::get() * 21_000;
+		let min_ethereum_transaction_weight = WeightPerGas::get() * 21_000;
 		let base_extrinsic = <Runtime as frame_system::Config>::BlockWeights::get()
 			.get(frame_support::dispatch::DispatchClass::Normal)
 			.base_extrinsic;

--- a/runtime/crab/src/lib.rs
+++ b/runtime/crab/src/lib.rs
@@ -36,34 +36,14 @@ pub use darwinia_common_runtime::*;
 pub use dc_primitives::*;
 pub use sp_consensus_aura::sr25519::AuthorityId as AuraId;
 
-// cumulus
-use cumulus_pallet_parachain_system::RelayNumberStrictlyIncreases;
-// polkadot
-use xcm_executor::XcmExecutor;
 // substrate
-use frame_support::{
-	dispatch::DispatchClass,
-	traits::{AsEnsureOriginWithArg, Imbalance, IsInVec, OnUnbalanced, WithdrawReasons},
-	weights::{ConstantMultiplier, Weight},
-};
-use frame_system::{EnsureRoot, EnsureSignedBy};
-use sp_core::{crypto::KeyTypeId, OpaqueMetadata, H160, H256, U256};
-use sp_runtime::{
-	generic,
-	traits::Block as BlockT,
-	transaction_validity::{TransactionSource, TransactionValidity},
-	ApplyExtrinsicResult, Perbill, Permill,
-};
 use sp_std::prelude::*;
-#[cfg(feature = "std")]
-use sp_version::NativeVersion;
-use sp_version::RuntimeVersion;
 
 /// Block type as expected by this runtime.
-pub type Block = generic::Block<Header, UncheckedExtrinsic>;
+pub type Block = sp_runtime::generic::Block<Header, UncheckedExtrinsic>;
 
 /// A Block signed with a Justification
-pub type SignedBlock = generic::SignedBlock<Block>;
+pub type SignedBlock = sp_runtime::generic::SignedBlock<Block>;
 
 /// The SignedExtension to the basic transaction logic.
 pub type SignedExtra = (
@@ -84,7 +64,7 @@ pub type UncheckedExtrinsic =
 
 /// Extrinsic type that has already been checked.
 pub type CheckedExtrinsic =
-	fp_self_contained::CheckedExtrinsic<AccountId, RuntimeCall, SignedExtra, H160>;
+	fp_self_contained::CheckedExtrinsic<AccountId, RuntimeCall, SignedExtra, sp_core::H160>;
 
 /// Executive: handles dispatch to the various modules.
 pub type Executive = frame_executive::Executive<
@@ -100,7 +80,7 @@ pub const DARWINIA_PROPOSAL_REQUIREMENT: Balance = 5000 * UNIT;
 
 /// Runtime version.
 #[sp_version::runtime_version]
-pub const VERSION: RuntimeVersion = RuntimeVersion {
+pub const VERSION: sp_version::RuntimeVersion = sp_version::RuntimeVersion {
 	spec_name: sp_runtime::create_runtime_str!("Crab2"),
 	impl_name: sp_runtime::create_runtime_str!("DarwiniaOfficialRust"),
 	authoring_version: 0,
@@ -118,37 +98,48 @@ impl<R> frame_support::traits::OnUnbalanced<pallet_balances::NegativeImbalance<R
 where
 	R: pallet_balances::Config,
 	R: pallet_balances::Config + pallet_treasury::Config,
-	pallet_treasury::Pallet<R>: OnUnbalanced<pallet_balances::NegativeImbalance<R>>,
+	pallet_treasury::Pallet<R>:
+		frame_support::traits::OnUnbalanced<pallet_balances::NegativeImbalance<R>>,
 {
 	// this seems to be called for substrate-based transactions
 	fn on_unbalanceds<B>(
 		mut fees_then_tips: impl Iterator<Item = pallet_balances::NegativeImbalance<R>>,
 	) {
 		if let Some(fees) = fees_then_tips.next() {
+			// substrate
+			use frame_support::traits::Imbalance;
+
 			// for fees, 80% are burned, 20% to the treasury
 			let (_, to_treasury) = fees.ration(80, 20);
 
 			// Balances pallet automatically burns dropped Negative Imbalances by decreasing
 			// total_supply accordingly
-			<pallet_treasury::Pallet<R> as OnUnbalanced<_>>::on_unbalanced(to_treasury);
+			<pallet_treasury::Pallet<R> as frame_support::traits::OnUnbalanced<_>>::on_unbalanced(
+				to_treasury,
+			);
 		}
 	}
 
 	// this is called from pallet_evm for Ethereum-based transactions
 	// (technically, it calls on_unbalanced, which calls this when non-zero)
 	fn on_nonzero_unbalanced(amount: pallet_balances::NegativeImbalance<R>) {
+		// substrate
+		use frame_support::traits::Imbalance;
+
 		// Balances pallet automatically burns dropped Negative Imbalances by decreasing
 		// total_supply accordingly
 		let (_, to_treasury) = amount.ration(80, 20);
 
-		<pallet_treasury::Pallet<R> as OnUnbalanced<_>>::on_unbalanced(to_treasury);
+		<pallet_treasury::Pallet<R> as frame_support::traits::OnUnbalanced<_>>::on_unbalanced(
+			to_treasury,
+		);
 	}
 }
 
 /// The version information used to identify this runtime when compiled natively.
 #[cfg(feature = "std")]
-pub fn native_version() -> NativeVersion {
-	NativeVersion { runtime_version: VERSION, can_author_with: Default::default() }
+pub fn native_version() -> sp_version::NativeVersion {
+	sp_version::NativeVersion { runtime_version: VERSION, can_author_with: Default::default() }
 }
 
 // Create the runtime by composing the FRAME pallets that were previously configured.
@@ -255,7 +246,7 @@ sp_api::impl_runtime_apis! {
 	}
 
 	impl sp_api::Core<Block> for Runtime {
-		fn version() -> RuntimeVersion {
+		fn version() -> sp_version::RuntimeVersion {
 			VERSION
 		}
 
@@ -263,27 +254,27 @@ sp_api::impl_runtime_apis! {
 			Executive::execute_block(block)
 		}
 
-		fn initialize_block(header: &<Block as BlockT>::Header) {
+		fn initialize_block(header: &<Block as sp_runtime::traits::Block>::Header) {
 			Executive::initialize_block(header)
 		}
 	}
 
 	impl sp_api::Metadata<Block> for Runtime {
-		fn metadata() -> OpaqueMetadata {
-			OpaqueMetadata::new(Runtime::metadata().into())
+		fn metadata() -> sp_core::OpaqueMetadata {
+			sp_core::OpaqueMetadata::new(Runtime::metadata().into())
 		}
 	}
 
 	impl sp_block_builder::BlockBuilder<Block> for Runtime {
-		fn apply_extrinsic(extrinsic: <Block as BlockT>::Extrinsic) -> ApplyExtrinsicResult {
+		fn apply_extrinsic(extrinsic: <Block as sp_runtime::traits::Block>::Extrinsic) -> sp_runtime::ApplyExtrinsicResult {
 			Executive::apply_extrinsic(extrinsic)
 		}
 
-		fn finalize_block() -> <Block as BlockT>::Header {
+		fn finalize_block() -> <Block as sp_runtime::traits::Block>::Header {
 			Executive::finalize_block()
 		}
 
-		fn inherent_extrinsics(data: sp_inherents::InherentData) -> Vec<<Block as BlockT>::Extrinsic> {
+		fn inherent_extrinsics(data: sp_inherents::InherentData) -> Vec<<Block as sp_runtime::traits::Block>::Extrinsic> {
 			data.create_extrinsics()
 		}
 
@@ -297,16 +288,16 @@ sp_api::impl_runtime_apis! {
 
 	impl sp_transaction_pool::runtime_api::TaggedTransactionQueue<Block> for Runtime {
 		fn validate_transaction(
-			source: TransactionSource,
-			tx: <Block as BlockT>::Extrinsic,
-			block_hash: <Block as BlockT>::Hash,
-		) -> TransactionValidity {
+			source: sp_runtime::transaction_validity::TransactionSource,
+			tx: <Block as sp_runtime::traits::Block>::Extrinsic,
+			block_hash: <Block as sp_runtime::traits::Block>::Hash,
+		) -> sp_runtime::transaction_validity::TransactionValidity {
 			Executive::validate_transaction(source, tx, block_hash)
 		}
 	}
 
 	impl sp_offchain::OffchainWorkerApi<Block> for Runtime {
-		fn offchain_worker(header: &<Block as BlockT>::Header) {
+		fn offchain_worker(header: &<Block as sp_runtime::traits::Block>::Header) {
 			Executive::offchain_worker(header)
 		}
 	}
@@ -318,7 +309,7 @@ sp_api::impl_runtime_apis! {
 
 		fn decode_session_keys(
 			encoded: Vec<u8>,
-		) -> Option<Vec<(Vec<u8>, KeyTypeId)>> {
+		) -> Option<Vec<(Vec<u8>, sp_runtime::KeyTypeId)>> {
 			SessionKeys::decode_into_raw_public_keys(&encoded)
 		}
 	}
@@ -331,13 +322,13 @@ sp_api::impl_runtime_apis! {
 
 	impl pallet_transaction_payment_rpc_runtime_api::TransactionPaymentApi<Block, Balance> for Runtime {
 		fn query_info(
-			uxt: <Block as BlockT>::Extrinsic,
+			uxt: <Block as sp_runtime::traits::Block>::Extrinsic,
 			len: u32,
 		) -> pallet_transaction_payment_rpc_runtime_api::RuntimeDispatchInfo<Balance> {
 			TransactionPayment::query_info(uxt, len)
 		}
 		fn query_fee_details(
-			uxt: <Block as BlockT>::Extrinsic,
+			uxt: <Block as sp_runtime::traits::Block>::Extrinsic,
 			len: u32,
 		) -> pallet_transaction_payment::FeeDetails<Balance> {
 			TransactionPayment::query_fee_details(uxt, len)
@@ -362,7 +353,7 @@ sp_api::impl_runtime_apis! {
 	}
 
 	impl cumulus_primitives_core::CollectCollationInfo<Block> for Runtime {
-		fn collect_collation_info(header: &<Block as BlockT>::Header) -> cumulus_primitives_core::CollationInfo {
+		fn collect_collation_info(header: &<Block as sp_runtime::traits::Block>::Header) -> cumulus_primitives_core::CollationInfo {
 			ParachainSystem::collect_collation_info(header)
 		}
 	}
@@ -372,13 +363,13 @@ sp_api::impl_runtime_apis! {
 			<<Runtime as pallet_evm::Config>::ChainId as frame_support::traits::Get<u64>>::get()
 		}
 
-		fn account_basic(address: H160) -> pallet_evm::Account {
+		fn account_basic(address: sp_core::H160) -> pallet_evm::Account {
 			let (account, _) = Evm::account_basic(&address);
 
 			account
 		}
 
-		fn gas_price() -> U256 {
+		fn gas_price() -> sp_core::U256 {
 			// frontier
 			use pallet_evm::FeeCalculator;
 
@@ -387,33 +378,33 @@ sp_api::impl_runtime_apis! {
 			gas_price
 		}
 
-		fn account_code_at(address: H160) -> Vec<u8> {
+		fn account_code_at(address: sp_core::H160) -> Vec<u8> {
 			Evm::account_codes(address)
 		}
 
-		fn author() -> H160 {
+		fn author() -> sp_core::H160 {
 			<pallet_evm::Pallet<Runtime>>::find_author()
 		}
 
-		fn storage_at(address: H160, index: U256) -> H256 {
+		fn storage_at(address: sp_core::H160, index: sp_core::U256) -> sp_core::H256 {
 			let mut tmp = [0u8; 32];
 
 			index.to_big_endian(&mut tmp);
 
-			Evm::account_storages(address, H256::from_slice(&tmp[..]))
+			Evm::account_storages(address, sp_core::H256::from_slice(&tmp[..]))
 		}
 
 		fn call(
-			from: H160,
-			to: H160,
+			from: sp_core::H160,
+			to: sp_core::H160,
 			data: Vec<u8>,
-			value: U256,
-			gas_limit: U256,
-			max_fee_per_gas: Option<U256>,
-			max_priority_fee_per_gas: Option<U256>,
-			nonce: Option<U256>,
+			value: sp_core::U256,
+			gas_limit: sp_core::U256,
+			max_fee_per_gas: Option<sp_core::U256>,
+			max_priority_fee_per_gas: Option<sp_core::U256>,
+			nonce: Option<sp_core::U256>,
 			estimate: bool,
-			access_list: Option<Vec<(H160, Vec<H256>)>>,
+			access_list: Option<Vec<(sp_core::H160, Vec<sp_core::H256>)>>,
 		) -> Result<pallet_evm::CallInfo, sp_runtime::DispatchError> {
 			// frontier
 			use pallet_evm::Runner;
@@ -449,15 +440,15 @@ sp_api::impl_runtime_apis! {
 		}
 
 		fn create(
-			from: H160,
+			from: sp_core::H160,
 			data: Vec<u8>,
-			value: U256,
-			gas_limit: U256,
-			max_fee_per_gas: Option<U256>,
-			max_priority_fee_per_gas: Option<U256>,
-			nonce: Option<U256>,
+			value: sp_core::U256,
+			gas_limit: sp_core::U256,
+			max_fee_per_gas: Option<sp_core::U256>,
+			max_priority_fee_per_gas: Option<sp_core::U256>,
+			nonce: Option<sp_core::U256>,
 			estimate: bool,
-			access_list: Option<Vec<(H160, Vec<H256>)>>,
+			access_list: Option<Vec<(sp_core::H160, Vec<sp_core::H256>)>>,
 		) -> Result<pallet_evm::CreateInfo, sp_runtime::DispatchError> {
 			// frontier
 			use pallet_evm::Runner;
@@ -516,7 +507,7 @@ sp_api::impl_runtime_apis! {
 		}
 
 		fn extrinsic_filter(
-			xts: Vec<<Block as BlockT>::Extrinsic>,
+			xts: Vec<<Block as sp_runtime::traits::Block>::Extrinsic>,
 		) -> Vec<pallet_ethereum::Transaction> {
 			xts.into_iter().filter_map(|xt| match xt.0.function {
 				RuntimeCall::Ethereum(
@@ -526,7 +517,7 @@ sp_api::impl_runtime_apis! {
 			}).collect::<Vec<pallet_ethereum::Transaction>>()
 		}
 
-		fn elasticity() -> Option<Permill> {
+		fn elasticity() -> Option<sp_runtime::Permill> {
 			None
 		}
 
@@ -536,7 +527,7 @@ sp_api::impl_runtime_apis! {
 	impl fp_rpc::ConvertTransactionRuntimeApi<Block> for Runtime {
 		fn convert_transaction(
 			transaction: pallet_ethereum::Transaction
-		) -> <Block as BlockT>::Extrinsic {
+		) -> <Block as sp_runtime::traits::Block>::Extrinsic {
 			UncheckedExtrinsic::new_unsigned(
 				pallet_ethereum::Call::<Runtime>::transact { transaction }.into(),
 			)
@@ -602,7 +593,7 @@ sp_api::impl_runtime_apis! {
 
 	#[cfg(feature = "try-runtime")]
 	impl frame_try_runtime::TryRuntime<Block> for Runtime {
-		fn on_runtime_upgrade(checks: bool) -> (Weight, Weight) {
+		fn on_runtime_upgrade(checks: bool) -> (Weight, frame_support::weights::Weight) {
 			// substrate
 			use frame_support::log;
 
@@ -662,9 +653,9 @@ mod tests {
 
 	#[test]
 	fn configured_base_extrinsic_weight_is_evm_compatible() {
-		let min_ethereum_transaction_weight = WeightPerGas::get() * 21_000;
+		let min_ethereum_transaction_weight = frame_support::weights::WeightPerGas::get() * 21_000;
 		let base_extrinsic = <Runtime as frame_system::Config>::BlockWeights::get()
-			.get(DispatchClass::Normal)
+			.get(frame_support::dispatch::DispatchClass::Normal)
 			.base_extrinsic;
 
 		assert!(base_extrinsic.ref_time() <= min_ethereum_transaction_weight.ref_time());

--- a/runtime/crab/src/pallets/assets.rs
+++ b/runtime/crab/src/pallets/assets.rs
@@ -37,10 +37,12 @@ impl pallet_assets::Config for Runtime {
 	type Balance = Balance;
 	#[cfg(feature = "runtime-benchmarks")]
 	type BenchmarkHelper = ();
-	type CreateOrigin = AsEnsureOriginWithArg<EnsureSignedBy<IsInVec<Creators>, AccountId>>;
+	type CreateOrigin = frame_support::traits::AsEnsureOriginWithArg<
+		frame_system::EnsureSignedBy<frame_support::traits::IsInVec<Creators>, AccountId>,
+	>;
 	type Currency = Balances;
 	type Extra = ();
-	type ForceOrigin = EnsureRoot<AccountId>;
+	type ForceOrigin = frame_system::EnsureRoot<AccountId>;
 	type Freezer = ();
 	type MetadataDepositBase = ConstU128<0>;
 	type MetadataDepositPerByte = ConstU128<0>;

--- a/runtime/crab/src/pallets/bridge_dispatch.rs
+++ b/runtime/crab/src/pallets/bridge_dispatch.rs
@@ -34,7 +34,7 @@ impl bp_message_dispatch::CallValidate<AccountId, RuntimeOrigin, RuntimeCall> fo
 				let total_payment =
 					darwinia_message_transact::total_payment::<Runtime>((&**tx).into());
 				let relayer =
-					pallet_evm::Pallet::<Runtime>::account_basic(&H160(relayer_account.0)).0;
+					pallet_evm::Pallet::<Runtime>::account_basic(&sp_core::H160(relayer_account.0)).0;
 
 				frame_support::ensure!(relayer.balance >= total_payment, "Insufficient balance");
 				Ok(())
@@ -87,7 +87,7 @@ impl bp_message_dispatch::IntoDispatchOrigin<AccountId, RuntimeCall, RuntimeOrig
 		match call {
 			RuntimeCall::MessageTransact(darwinia_message_transact::Call::message_transact {
 				..
-			}) => darwinia_message_transact::LcmpEthOrigin::MessageTransact(H160(id.0)).into(),
+			}) => darwinia_message_transact::LcmpEthOrigin::MessageTransact(sp_core::H160(id.0)).into(),
 			_ => frame_system::RawOrigin::Signed(*id).into(),
 		}
 	}

--- a/runtime/crab/src/pallets/dmp_queue.rs
+++ b/runtime/crab/src/pallets/dmp_queue.rs
@@ -20,7 +20,7 @@
 use crate::*;
 
 impl cumulus_pallet_dmp_queue::Config for Runtime {
-	type ExecuteOverweightOrigin = EnsureRoot<AccountId>;
+	type ExecuteOverweightOrigin = frame_system::EnsureRoot<AccountId>;
 	type RuntimeEvent = RuntimeEvent;
-	type XcmExecutor = XcmExecutor<XcmExecutorConfig>;
+	type XcmExecutor = xcm_executor::XcmExecutor<XcmExecutorConfig>;
 }

--- a/runtime/crab/src/pallets/evm.rs
+++ b/runtime/crab/src/pallets/evm.rs
@@ -24,16 +24,16 @@ use pallet_evm::Precompile;
 const WEIGHT_PER_GAS: u64 = 40_000;
 
 frame_support::parameter_types! {
-	pub BlockGasLimit: U256 = U256::from(NORMAL_DISPATCH_RATIO * MAXIMUM_BLOCK_WEIGHT.ref_time() / WEIGHT_PER_GAS);
+	pub BlockGasLimit: sp_core::U256 = sp_core::U256::from(NORMAL_DISPATCH_RATIO * MAXIMUM_BLOCK_WEIGHT.ref_time() / WEIGHT_PER_GAS);
 	pub PrecompilesValue: CrabPrecompiles<Runtime> = CrabPrecompiles::<_>::new();
-	pub WeightPerGas: Weight = Weight::from_ref_time(WEIGHT_PER_GAS);
+	pub WeightPerGas: frame_support::weights::Weight = frame_support::weights::Weight::from_ref_time(WEIGHT_PER_GAS);
 }
 
 pub struct FindAuthorTruncated<F>(sp_std::marker::PhantomData<F>);
-impl<F: frame_support::traits::FindAuthor<u32>> frame_support::traits::FindAuthor<H160>
+impl<F: frame_support::traits::FindAuthor<u32>> frame_support::traits::FindAuthor<sp_core::H160>
 	for FindAuthorTruncated<F>
 {
-	fn find_author<'a, I>(digests: I) -> Option<H160>
+	fn find_author<'a, I>(digests: I) -> Option<sp_core::H160>
 	where
 		I: 'a + IntoIterator<Item = (frame_support::ConsensusEngineId, &'a [u8])>,
 	{
@@ -45,7 +45,7 @@ impl<F: frame_support::traits::FindAuthor<u32>> frame_support::traits::FindAutho
 				let raw = id.to_raw_vec();
 
 				if raw.len() >= 24 {
-					Some(H160::from_slice(&raw[4..24]))
+					Some(sp_core::H160::from_slice(&raw[4..24]))
 				} else {
 					None
 				}
@@ -56,8 +56,8 @@ impl<F: frame_support::traits::FindAuthor<u32>> frame_support::traits::FindAutho
 
 pub struct FixedGasPrice;
 impl pallet_evm::FeeCalculator for FixedGasPrice {
-	fn min_gas_price() -> (U256, Weight) {
-		(U256::from(GWEI), Weight::zero())
+	fn min_gas_price() -> (sp_core::U256, frame_support::weights::Weight) {
+		(sp_core::U256::from(GWEI), frame_support::weights::Weight::zero())
 	}
 }
 
@@ -65,9 +65,9 @@ impl pallet_evm::FeeCalculator for FixedGasPrice {
 pub struct FromH160;
 impl<T> pallet_evm::AddressMapping<T> for FromH160
 where
-	T: From<H160>,
+	T: From<sp_core::H160>,
 {
-	fn into_account_id(address: H160) -> T {
+	fn into_account_id(address: sp_core::H160) -> T {
 		address.into()
 	}
 }
@@ -75,7 +75,7 @@ where
 pub struct AssetIdConverter;
 impl darwinia_precompile_assets::AccountToAssetId<AccountId, AssetId> for AssetIdConverter {
 	fn account_to_asset_id(account_id: AccountId) -> AssetId {
-		let addr: H160 = account_id.into();
+		let addr: sp_core::H160 = account_id.into();
 		addr.to_low_u64_be()
 	}
 }
@@ -90,7 +90,7 @@ where
 		Self(Default::default())
 	}
 
-	pub fn used_addresses() -> [H160; 15] {
+	pub fn used_addresses() -> [sp_core::H160; 15] {
 		[
 			addr(1),
 			addr(2),
@@ -164,7 +164,7 @@ where
 		}
 	}
 
-	fn is_precompile(&self, address: H160) -> bool {
+	fn is_precompile(&self, address: sp_core::H160) -> bool {
 		Self::used_addresses().contains(&address)
 	}
 }
@@ -188,6 +188,6 @@ impl pallet_evm::Config for Runtime {
 	type WithdrawOrigin = pallet_evm::EnsureAddressNever<AccountId>;
 }
 
-fn addr(a: u64) -> H160 {
-	H160::from_low_u64_be(a)
+fn addr(a: u64) -> sp_core::H160 {
+	sp_core::H160::from_low_u64_be(a)
 }

--- a/runtime/crab/src/pallets/parachain_system.rs
+++ b/runtime/crab/src/pallets/parachain_system.rs
@@ -20,12 +20,12 @@
 use crate::*;
 
 frame_support::parameter_types! {
-	pub const ReservedXcmpWeight: Weight = MAXIMUM_BLOCK_WEIGHT.saturating_div(4);
-	pub const ReservedDmpWeight: Weight = MAXIMUM_BLOCK_WEIGHT.saturating_div(4);
+	pub const ReservedXcmpWeight: frame_support::weights::Weight = MAXIMUM_BLOCK_WEIGHT.saturating_div(4);
+	pub const ReservedDmpWeight: frame_support::weights::Weight = MAXIMUM_BLOCK_WEIGHT.saturating_div(4);
 }
 
 impl cumulus_pallet_parachain_system::Config for Runtime {
-	type CheckAssociatedRelayNumber = RelayNumberStrictlyIncreases;
+	type CheckAssociatedRelayNumber = cumulus_pallet_parachain_system::RelayNumberStrictlyIncreases;
 	type DmpMessageHandler = DmpQueue;
 	type OnSystemEvent = ();
 	type OutboundXcmpMessageSource = XcmpQueue;

--- a/runtime/crab/src/pallets/polkadot_xcm.rs
+++ b/runtime/crab/src/pallets/polkadot_xcm.rs
@@ -135,7 +135,7 @@ impl xcm_executor::Config for XcmExecutorConfig {
 	type RuntimeCall = RuntimeCall;
 	type SubscriptionService = PolkadotXcm;
 	type Trader = xcm_configs::LocalAssetTrader<
-		ConstantMultiplier<Balance, darwinia_common_runtime::xcm_configs::XcmBaseWeightFee>,
+		frame_support::weights::ConstantMultiplier<Balance, darwinia_common_runtime::xcm_configs::XcmBaseWeightFee>,
 		AnchoringSelfReserve,
 		AccountId,
 		Balances,

--- a/runtime/crab/src/pallets/preimage.rs
+++ b/runtime/crab/src/pallets/preimage.rs
@@ -23,7 +23,7 @@ impl pallet_preimage::Config for Runtime {
 	type BaseDeposit = ConstU128<{ 500 * UNIT }>;
 	type ByteDeposit = ConstU128<{ darwinia_deposit(0, 1) }>;
 	type Currency = Balances;
-	type ManagerOrigin = EnsureRoot<AccountId>;
+	type ManagerOrigin = frame_system::EnsureRoot<AccountId>;
 	type RuntimeEvent = RuntimeEvent;
 	type WeightInfo = ();
 }

--- a/runtime/crab/src/pallets/system.rs
+++ b/runtime/crab/src/pallets/system.rs
@@ -21,17 +21,18 @@ use crate::*;
 
 /// We assume that ~5% of the block weight is consumed by `on_initialize` handlers. This is
 /// used to limit the maximal weight of a single extrinsic.
-const AVERAGE_ON_INITIALIZE_RATIO: Perbill = Perbill::from_percent(5);
+const AVERAGE_ON_INITIALIZE_RATIO: sp_runtime::Perbill = sp_runtime::Perbill::from_percent(5);
 
 /// We allow `Normal` extrinsics to fill up the block up to 75%, the rest can be used by
 /// `Operational` extrinsics.
-pub const NORMAL_DISPATCH_RATIO: Perbill = Perbill::from_percent(75);
+pub const NORMAL_DISPATCH_RATIO: sp_runtime::Perbill = sp_runtime::Perbill::from_percent(75);
 
 /// We allow for 0.5 of a second of compute with a 12 second average block time.
-pub const MAXIMUM_BLOCK_WEIGHT: Weight = Weight::from_parts(
-	frame_support::weights::constants::WEIGHT_REF_TIME_PER_SECOND.saturating_div(2),
-	cumulus_primitives_core::relay_chain::v2::MAX_POV_SIZE as u64,
-);
+pub const MAXIMUM_BLOCK_WEIGHT: frame_support::weights::Weight =
+	frame_support::weights::Weight::from_parts(
+		frame_support::weights::constants::WEIGHT_REF_TIME_PER_SECOND.saturating_div(2),
+		cumulus_primitives_core::relay_chain::v2::MAX_POV_SIZE as u64,
+	);
 
 frame_support::parameter_types! {
 	pub const Version: sp_version::RuntimeVersion = VERSION;
@@ -39,13 +40,13 @@ frame_support::parameter_types! {
 		frame_system::limits::BlockLength::max_with_normal_ratio(5 * 1024 * 1024, NORMAL_DISPATCH_RATIO);
 	pub RuntimeBlockWeights: frame_system::limits::BlockWeights = frame_system::limits::BlockWeights::builder()
 		.base_block(weights::BlockExecutionWeight::get())
-		.for_class(DispatchClass::all(), |weights| {
+		.for_class(frame_support::dispatch::DispatchClass::all(), |weights| {
 			weights.base_extrinsic = weights::ExtrinsicBaseWeight::get();
 		})
-		.for_class(DispatchClass::Normal, |weights| {
+		.for_class(frame_support::dispatch::DispatchClass::Normal, |weights| {
 			weights.max_total = Some(NORMAL_DISPATCH_RATIO * MAXIMUM_BLOCK_WEIGHT);
 		})
-		.for_class(DispatchClass::Operational, |weights| {
+		.for_class(frame_support::dispatch::DispatchClass::Operational, |weights| {
 			weights.max_total = Some(MAXIMUM_BLOCK_WEIGHT);
 			// Operational transactions have some extra reserved space, so that they
 			// are included even if block reached `MAXIMUM_BLOCK_WEIGHT`.
@@ -79,7 +80,7 @@ impl frame_system::Config for Runtime {
 	/// The hashing algorithm used.
 	type Hashing = Hashing;
 	/// The header type.
-	type Header = generic::Header<BlockNumber, Self::Hashing>;
+	type Header = sp_runtime::generic::Header<BlockNumber, Self::Hashing>;
 	/// The index type for storing how many extrinsics an account has signed.
 	type Index = Index;
 	/// The lookup mechanism to get account ID from whatever is passed in dispatchers.

--- a/runtime/crab/src/pallets/transaction_payment.rs
+++ b/runtime/crab/src/pallets/transaction_payment.rs
@@ -22,7 +22,7 @@ use crate::*;
 impl pallet_transaction_payment::Config for Runtime {
 	type FeeMultiplierUpdate = polkadot_runtime_common::SlowAdjustingFeeUpdate<Self>;
 	// Relay Chain `TransactionByteFee` / 10
-	type LengthToFee = ConstantMultiplier<Balance, ConstU128<{ 10 * MICROUNIT }>>;
+	type LengthToFee = frame_support::weights::ConstantMultiplier<Balance, ConstU128<{ 10 * MICROUNIT }>>;
 	type OnChargeTransaction =
 		pallet_transaction_payment::CurrencyAdapter<Balances, DealWithFees<Runtime>>;
 	type OperationalFeeMultiplier = sp_runtime::traits::ConstU8<5>;

--- a/runtime/crab/src/pallets/vesting.rs
+++ b/runtime/crab/src/pallets/vesting.rs
@@ -20,8 +20,10 @@
 use crate::*;
 
 frame_support::parameter_types! {
-	pub UnvestedFundsAllowedWithdrawReasons: WithdrawReasons =
-		WithdrawReasons::except(WithdrawReasons::TRANSFER | WithdrawReasons::RESERVE);
+	pub UnvestedFundsAllowedWithdrawReasons: frame_support::traits::WithdrawReasons =
+		frame_support::traits::WithdrawReasons::except(
+			frame_support::traits::WithdrawReasons::TRANSFER | frame_support::traits::WithdrawReasons::RESERVE
+		);
 }
 
 impl pallet_vesting::Config for Runtime {

--- a/runtime/crab/src/pallets/xcmp_queue.rs
+++ b/runtime/crab/src/pallets/xcmp_queue.rs
@@ -21,11 +21,11 @@ use crate::*;
 
 impl cumulus_pallet_xcmp_queue::Config for Runtime {
 	type ChannelInfo = ParachainSystem;
-	type ControllerOrigin = EnsureRoot<AccountId>;
+	type ControllerOrigin = frame_system::EnsureRoot<AccountId>;
 	type ControllerOriginConverter = XcmOriginToTransactDispatchOrigin;
-	type ExecuteOverweightOrigin = EnsureRoot<AccountId>;
+	type ExecuteOverweightOrigin = frame_system::EnsureRoot<AccountId>;
 	type RuntimeEvent = RuntimeEvent;
 	type VersionWrapper = ();
 	type WeightInfo = weights::cumulus_pallet_xcmp_queue::WeightInfo<Self>;
-	type XcmExecutor = XcmExecutor<XcmExecutorConfig>;
+	type XcmExecutor = xcm_executor::XcmExecutor<XcmExecutorConfig>;
 }

--- a/runtime/crab/src/weights/block_weights.rs
+++ b/runtime/crab/src/weights/block_weights.rs
@@ -16,35 +16,31 @@
 // limitations under the License.
 
 pub mod constants {
-	use frame_support::{
-		parameter_types,
-		weights::{constants, Weight},
-	};
-
-	parameter_types! {
+	frame_support::parameter_types! {
 		/// Importing a block with 0 Extrinsics.
-		pub const BlockExecutionWeight: Weight = Weight::from_ref_time(constants::WEIGHT_REF_TIME_PER_NANOS.saturating_mul(5_000_000));
+		pub const BlockExecutionWeight: frame_support::weights::Weight =
+			frame_support::weights::Weight::from_ref_time(frame_support::weights::constants::WEIGHT_REF_TIME_PER_NANOS.saturating_mul(5_000_000));
 	}
 
 	#[cfg(test)]
 	mod test_weights {
-		use frame_support::weights::constants;
-
 		/// Checks that the weight exists and is sane.
 		// NOTE: If this test fails but you are sure that the generated values are fine,
 		// you can delete it.
 		#[test]
 		fn sane() {
-			let w = super::constants::BlockExecutionWeight::get();
+			let w = frame_support::weights::constants::BlockExecutionWeight::get();
 
 			// At least 100 µs.
 			assert!(
-				w.ref_time() >= 100u64 * constants::WEIGHT_REF_TIME_PER_MICROS,
+				w.ref_time()
+					>= 100u64 * frame_support::weights::constants::WEIGHT_REF_TIME_PER_MICROS,
 				"Weight should be at least 100 µs."
 			);
 			// At most 50 ms.
 			assert!(
-				w.ref_time() <= 50u64 * constants::WEIGHT_REF_TIME_PER_MILLIS,
+				w.ref_time()
+					<= 50u64 * frame_support::weights::constants::WEIGHT_REF_TIME_PER_MILLIS,
 				"Weight should be at most 50 ms."
 			);
 		}

--- a/runtime/crab/src/weights/extrinsic_weights.rs
+++ b/runtime/crab/src/weights/extrinsic_weights.rs
@@ -16,35 +16,30 @@
 // limitations under the License.
 
 pub mod constants {
-	use frame_support::{
-		parameter_types,
-		weights::{constants, Weight},
-	};
-
-	parameter_types! {
+	frame_support::parameter_types! {
 		/// Executing a NO-OP `System::remarks` Extrinsic.
-		pub const ExtrinsicBaseWeight: Weight = Weight::from_ref_time(constants::WEIGHT_REF_TIME_PER_NANOS.saturating_mul(125_000));
+		pub const ExtrinsicBaseWeight: frame_support::weights::Weight =
+			frame_support::weights::Weight::from_ref_time(frame_support::weights::constants::WEIGHT_REF_TIME_PER_NANOS.saturating_mul(125_000));
 	}
 
 	#[cfg(test)]
 	mod test_weights {
-		use frame_support::weights::constants;
-
 		/// Checks that the weight exists and is sane.
 		// NOTE: If this test fails but you are sure that the generated values are fine,
 		// you can delete it.
 		#[test]
 		fn sane() {
-			let w = super::constants::ExtrinsicBaseWeight::get();
+			let w = frame_support::weights::constants::ExtrinsicBaseWeight::get();
 
 			// At least 10 µs.
 			assert!(
-				w.ref_time() >= 10u64 * constants::WEIGHT_REF_TIME_PER_MICROS,
+				w.ref_time()
+					>= 10u64 * frame_support::weights::constants::WEIGHT_REF_TIME_PER_MICROS,
 				"Weight should be at least 10 µs."
 			);
 			// At most 1 ms.
 			assert!(
-				w.ref_time() <= constants::WEIGHT_REF_TIME_PER_MILLIS,
+				w.ref_time() <= frame_support::weights::constants::WEIGHT_REF_TIME_PER_MILLIS,
 				"Weight should be at most 1 ms."
 			);
 		}

--- a/runtime/darwinia/src/lib.rs
+++ b/runtime/darwinia/src/lib.rs
@@ -648,13 +648,11 @@ cumulus_pallet_parachain_system::register_validate_block! {
 #[cfg(test)]
 mod tests {
 	// darwinia
-	use super::{Runtime, WeightPerGas};
-	// substrate
-	use frame_support::dispatch::DispatchClass;
+	use super::*;
 
 	#[test]
 	fn configured_base_extrinsic_weight_is_evm_compatible() {
-		let min_ethereum_transaction_weight = frame_support::weights::WeightPerGas::get() * 21_000;
+		let min_ethereum_transaction_weight = WeightPerGas::get() * 21_000;
 		let base_extrinsic = <Runtime as frame_system::Config>::BlockWeights::get()
 			.get(frame_support::dispatch::DispatchClass::Normal)
 			.base_extrinsic;

--- a/runtime/darwinia/src/lib.rs
+++ b/runtime/darwinia/src/lib.rs
@@ -36,34 +36,14 @@ pub use darwinia_common_runtime::*;
 pub use dc_primitives::*;
 pub use sp_consensus_aura::sr25519::AuthorityId as AuraId;
 
-// cumulus
-use cumulus_pallet_parachain_system::RelayNumberStrictlyIncreases;
-// polkadot
-use xcm_executor::XcmExecutor;
 // substrate
-use frame_support::{
-	dispatch::DispatchClass,
-	traits::{AsEnsureOriginWithArg, Imbalance, IsInVec, OnUnbalanced, WithdrawReasons},
-	weights::{ConstantMultiplier, Weight},
-};
-use frame_system::{EnsureRoot, EnsureSignedBy};
-use sp_core::{crypto::KeyTypeId, OpaqueMetadata, H160, H256, U256};
-use sp_runtime::{
-	generic,
-	traits::Block as BlockT,
-	transaction_validity::{TransactionSource, TransactionValidity},
-	ApplyExtrinsicResult, Perbill, Permill,
-};
 use sp_std::prelude::*;
-#[cfg(feature = "std")]
-use sp_version::NativeVersion;
-use sp_version::RuntimeVersion;
 
 /// Block type as expected by this runtime.
-pub type Block = generic::Block<Header, UncheckedExtrinsic>;
+pub type Block = sp_runtime::generic::Block<Header, UncheckedExtrinsic>;
 
 /// A Block signed with a Justification
-pub type SignedBlock = generic::SignedBlock<Block>;
+pub type SignedBlock = sp_runtime::generic::SignedBlock<Block>;
 
 /// The SignedExtension to the basic transaction logic.
 pub type SignedExtra = (
@@ -84,7 +64,7 @@ pub type UncheckedExtrinsic =
 
 /// Extrinsic type that has already been checked.
 pub type CheckedExtrinsic =
-	fp_self_contained::CheckedExtrinsic<AccountId, RuntimeCall, SignedExtra, H160>;
+	fp_self_contained::CheckedExtrinsic<AccountId, RuntimeCall, SignedExtra, sp_core::H160>;
 
 /// Executive: handles dispatch to the various modules.
 pub type Executive = frame_executive::Executive<
@@ -100,7 +80,7 @@ pub const DARWINIA_PROPOSAL_REQUIREMENT: Balance = 5000 * UNIT;
 
 /// Runtime version.
 #[sp_version::runtime_version]
-pub const VERSION: RuntimeVersion = RuntimeVersion {
+pub const VERSION: sp_version::RuntimeVersion = sp_version::RuntimeVersion {
 	spec_name: sp_runtime::create_runtime_str!("Darwinia2"),
 	impl_name: sp_runtime::create_runtime_str!("DarwiniaOfficialRust"),
 	authoring_version: 0,
@@ -118,37 +98,48 @@ impl<R> frame_support::traits::OnUnbalanced<pallet_balances::NegativeImbalance<R
 where
 	R: pallet_balances::Config,
 	R: pallet_balances::Config + pallet_treasury::Config,
-	pallet_treasury::Pallet<R>: OnUnbalanced<pallet_balances::NegativeImbalance<R>>,
+	pallet_treasury::Pallet<R>:
+		frame_support::traits::OnUnbalanced<pallet_balances::NegativeImbalance<R>>,
 {
 	// this seems to be called for substrate-based transactions
 	fn on_unbalanceds<B>(
 		mut fees_then_tips: impl Iterator<Item = pallet_balances::NegativeImbalance<R>>,
 	) {
 		if let Some(fees) = fees_then_tips.next() {
+			// substrate
+			use frame_support::traits::Imbalance;
+
 			// for fees, 80% are burned, 20% to the treasury
 			let (_, to_treasury) = fees.ration(80, 20);
 
 			// Balances pallet automatically burns dropped Negative Imbalances by decreasing
 			// total_supply accordingly
-			<pallet_treasury::Pallet<R> as OnUnbalanced<_>>::on_unbalanced(to_treasury);
+			<pallet_treasury::Pallet<R> as frame_support::traits::OnUnbalanced<_>>::on_unbalanced(
+				to_treasury,
+			);
 		}
 	}
 
 	// this is called from pallet_evm for Ethereum-based transactions
 	// (technically, it calls on_unbalanced, which calls this when non-zero)
 	fn on_nonzero_unbalanced(amount: pallet_balances::NegativeImbalance<R>) {
+		// substrate
+		use frame_support::traits::Imbalance;
+
 		// Balances pallet automatically burns dropped Negative Imbalances by decreasing
 		// total_supply accordingly
 		let (_, to_treasury) = amount.ration(80, 20);
 
-		<pallet_treasury::Pallet<R> as OnUnbalanced<_>>::on_unbalanced(to_treasury);
+		<pallet_treasury::Pallet<R> as frame_support::traits::OnUnbalanced<_>>::on_unbalanced(
+			to_treasury,
+		);
 	}
 }
 
 /// The version information used to identify this runtime when compiled natively.
 #[cfg(feature = "std")]
-pub fn native_version() -> NativeVersion {
-	NativeVersion { runtime_version: VERSION, can_author_with: Default::default() }
+pub fn native_version() -> sp_version::NativeVersion {
+	sp_version::NativeVersion { runtime_version: VERSION, can_author_with: Default::default() }
 }
 
 // Create the runtime by composing the FRAME pallets that were previously configured.
@@ -255,7 +246,7 @@ sp_api::impl_runtime_apis! {
 	}
 
 	impl sp_api::Core<Block> for Runtime {
-		fn version() -> RuntimeVersion {
+		fn version() -> sp_version::RuntimeVersion {
 			VERSION
 		}
 
@@ -263,27 +254,27 @@ sp_api::impl_runtime_apis! {
 			Executive::execute_block(block)
 		}
 
-		fn initialize_block(header: &<Block as BlockT>::Header) {
+		fn initialize_block(header: &<Block as sp_runtime::traits::Block>::Header) {
 			Executive::initialize_block(header)
 		}
 	}
 
 	impl sp_api::Metadata<Block> for Runtime {
-		fn metadata() -> OpaqueMetadata {
-			OpaqueMetadata::new(Runtime::metadata().into())
+		fn metadata() -> sp_core::OpaqueMetadata {
+			sp_core::OpaqueMetadata::new(Runtime::metadata().into())
 		}
 	}
 
 	impl sp_block_builder::BlockBuilder<Block> for Runtime {
-		fn apply_extrinsic(extrinsic: <Block as BlockT>::Extrinsic) -> ApplyExtrinsicResult {
+		fn apply_extrinsic(extrinsic: <Block as sp_runtime::traits::Block>::Extrinsic) -> sp_runtime::ApplyExtrinsicResult {
 			Executive::apply_extrinsic(extrinsic)
 		}
 
-		fn finalize_block() -> <Block as BlockT>::Header {
+		fn finalize_block() -> <Block as sp_runtime::traits::Block>::Header {
 			Executive::finalize_block()
 		}
 
-		fn inherent_extrinsics(data: sp_inherents::InherentData) -> Vec<<Block as BlockT>::Extrinsic> {
+		fn inherent_extrinsics(data: sp_inherents::InherentData) -> Vec<<Block as sp_runtime::traits::Block>::Extrinsic> {
 			data.create_extrinsics()
 		}
 
@@ -297,16 +288,16 @@ sp_api::impl_runtime_apis! {
 
 	impl sp_transaction_pool::runtime_api::TaggedTransactionQueue<Block> for Runtime {
 		fn validate_transaction(
-			source: TransactionSource,
-			tx: <Block as BlockT>::Extrinsic,
-			block_hash: <Block as BlockT>::Hash,
-		) -> TransactionValidity {
+			source: sp_runtime::transaction_validity::TransactionSource,
+			tx: <Block as sp_runtime::traits::Block>::Extrinsic,
+			block_hash: <Block as sp_runtime::traits::Block>::Hash,
+		) -> sp_runtime::transaction_validity::TransactionValidity {
 			Executive::validate_transaction(source, tx, block_hash)
 		}
 	}
 
 	impl sp_offchain::OffchainWorkerApi<Block> for Runtime {
-		fn offchain_worker(header: &<Block as BlockT>::Header) {
+		fn offchain_worker(header: &<Block as sp_runtime::traits::Block>::Header) {
 			Executive::offchain_worker(header)
 		}
 	}
@@ -318,7 +309,7 @@ sp_api::impl_runtime_apis! {
 
 		fn decode_session_keys(
 			encoded: Vec<u8>,
-		) -> Option<Vec<(Vec<u8>, KeyTypeId)>> {
+		) -> Option<Vec<(Vec<u8>, sp_runtime::KeyTypeId)>> {
 			SessionKeys::decode_into_raw_public_keys(&encoded)
 		}
 	}
@@ -331,13 +322,13 @@ sp_api::impl_runtime_apis! {
 
 	impl pallet_transaction_payment_rpc_runtime_api::TransactionPaymentApi<Block, Balance> for Runtime {
 		fn query_info(
-			uxt: <Block as BlockT>::Extrinsic,
+			uxt: <Block as sp_runtime::traits::Block>::Extrinsic,
 			len: u32,
 		) -> pallet_transaction_payment_rpc_runtime_api::RuntimeDispatchInfo<Balance> {
 			TransactionPayment::query_info(uxt, len)
 		}
 		fn query_fee_details(
-			uxt: <Block as BlockT>::Extrinsic,
+			uxt: <Block as sp_runtime::traits::Block>::Extrinsic,
 			len: u32,
 		) -> pallet_transaction_payment::FeeDetails<Balance> {
 			TransactionPayment::query_fee_details(uxt, len)
@@ -362,7 +353,7 @@ sp_api::impl_runtime_apis! {
 	}
 
 	impl cumulus_primitives_core::CollectCollationInfo<Block> for Runtime {
-		fn collect_collation_info(header: &<Block as BlockT>::Header) -> cumulus_primitives_core::CollationInfo {
+		fn collect_collation_info(header: &<Block as sp_runtime::traits::Block>::Header) -> cumulus_primitives_core::CollationInfo {
 			ParachainSystem::collect_collation_info(header)
 		}
 	}
@@ -372,13 +363,13 @@ sp_api::impl_runtime_apis! {
 			<<Runtime as pallet_evm::Config>::ChainId as frame_support::traits::Get<u64>>::get()
 		}
 
-		fn account_basic(address: H160) -> pallet_evm::Account {
+		fn account_basic(address: sp_core::H160) -> pallet_evm::Account {
 			let (account, _) = Evm::account_basic(&address);
 
 			account
 		}
 
-		fn gas_price() -> U256 {
+		fn gas_price() -> sp_core::U256 {
 			// frontier
 			use pallet_evm::FeeCalculator;
 
@@ -387,33 +378,33 @@ sp_api::impl_runtime_apis! {
 			gas_price
 		}
 
-		fn account_code_at(address: H160) -> Vec<u8> {
+		fn account_code_at(address: sp_core::H160) -> Vec<u8> {
 			Evm::account_codes(address)
 		}
 
-		fn author() -> H160 {
+		fn author() -> sp_core::H160 {
 			<pallet_evm::Pallet<Runtime>>::find_author()
 		}
 
-		fn storage_at(address: H160, index: U256) -> H256 {
+		fn storage_at(address: sp_core::H160, index: sp_core::U256) -> sp_core::H256 {
 			let mut tmp = [0u8; 32];
 
 			index.to_big_endian(&mut tmp);
 
-			Evm::account_storages(address, H256::from_slice(&tmp[..]))
+			Evm::account_storages(address, sp_core::H256::from_slice(&tmp[..]))
 		}
 
 		fn call(
-			from: H160,
-			to: H160,
+			from: sp_core::H160,
+			to: sp_core::H160,
 			data: Vec<u8>,
-			value: U256,
-			gas_limit: U256,
-			max_fee_per_gas: Option<U256>,
-			max_priority_fee_per_gas: Option<U256>,
-			nonce: Option<U256>,
+			value: sp_core::U256,
+			gas_limit: sp_core::U256,
+			max_fee_per_gas: Option<sp_core::U256>,
+			max_priority_fee_per_gas: Option<sp_core::U256>,
+			nonce: Option<sp_core::U256>,
 			estimate: bool,
-			access_list: Option<Vec<(H160, Vec<H256>)>>,
+			access_list: Option<Vec<(sp_core::H160, Vec<sp_core::H256>)>>,
 		) -> Result<pallet_evm::CallInfo, sp_runtime::DispatchError> {
 			// frontier
 			use pallet_evm::Runner;
@@ -449,15 +440,15 @@ sp_api::impl_runtime_apis! {
 		}
 
 		fn create(
-			from: H160,
+			from: sp_core::H160,
 			data: Vec<u8>,
-			value: U256,
-			gas_limit: U256,
-			max_fee_per_gas: Option<U256>,
-			max_priority_fee_per_gas: Option<U256>,
-			nonce: Option<U256>,
+			value: sp_core::U256,
+			gas_limit: sp_core::U256,
+			max_fee_per_gas: Option<sp_core::U256>,
+			max_priority_fee_per_gas: Option<sp_core::U256>,
+			nonce: Option<sp_core::U256>,
 			estimate: bool,
-			access_list: Option<Vec<(H160, Vec<H256>)>>,
+			access_list: Option<Vec<(sp_core::H160, Vec<sp_core::H256>)>>,
 		) -> Result<pallet_evm::CreateInfo, sp_runtime::DispatchError> {
 			// frontier
 			use pallet_evm::Runner;
@@ -516,7 +507,7 @@ sp_api::impl_runtime_apis! {
 		}
 
 		fn extrinsic_filter(
-			xts: Vec<<Block as BlockT>::Extrinsic>,
+			xts: Vec<<Block as sp_runtime::traits::Block>::Extrinsic>,
 		) -> Vec<pallet_ethereum::Transaction> {
 			xts.into_iter().filter_map(|xt| match xt.0.function {
 				RuntimeCall::Ethereum(
@@ -526,7 +517,7 @@ sp_api::impl_runtime_apis! {
 			}).collect::<Vec<pallet_ethereum::Transaction>>()
 		}
 
-		fn elasticity() -> Option<Permill> {
+		fn elasticity() -> Option<sp_runtime::Permill> {
 			None
 		}
 
@@ -537,7 +528,7 @@ sp_api::impl_runtime_apis! {
 	impl fp_rpc::ConvertTransactionRuntimeApi<Block> for Runtime {
 		fn convert_transaction(
 			transaction: pallet_ethereum::Transaction
-		) -> <Block as BlockT>::Extrinsic {
+		) -> <Block as sp_runtime::traits::Block>::Extrinsic {
 			UncheckedExtrinsic::new_unsigned(
 				pallet_ethereum::Call::<Runtime>::transact { transaction }.into(),
 			)
@@ -603,7 +594,7 @@ sp_api::impl_runtime_apis! {
 
 	#[cfg(feature = "try-runtime")]
 	impl frame_try_runtime::TryRuntime<Block> for Runtime {
-		fn on_runtime_upgrade(checks: bool) -> (Weight, Weight) {
+		fn on_runtime_upgrade(checks: bool) -> (Weight, frame_support::weights::Weight) {
 			// substrate
 			use frame_support::log;
 
@@ -663,9 +654,9 @@ mod tests {
 
 	#[test]
 	fn configured_base_extrinsic_weight_is_evm_compatible() {
-		let min_ethereum_transaction_weight = WeightPerGas::get() * 21_000;
+		let min_ethereum_transaction_weight = frame_support::weights::WeightPerGas::get() * 21_000;
 		let base_extrinsic = <Runtime as frame_system::Config>::BlockWeights::get()
-			.get(DispatchClass::Normal)
+			.get(frame_support::dispatch::DispatchClass::Normal)
 			.base_extrinsic;
 
 		assert!(base_extrinsic.ref_time() <= min_ethereum_transaction_weight.ref_time());

--- a/runtime/darwinia/src/pallets/assets.rs
+++ b/runtime/darwinia/src/pallets/assets.rs
@@ -37,10 +37,12 @@ impl pallet_assets::Config for Runtime {
 	type Balance = Balance;
 	#[cfg(feature = "runtime-benchmarks")]
 	type BenchmarkHelper = ();
-	type CreateOrigin = AsEnsureOriginWithArg<EnsureSignedBy<IsInVec<Creators>, AccountId>>;
+	type CreateOrigin = frame_support::traits::AsEnsureOriginWithArg<
+		frame_system::EnsureSignedBy<frame_support::traits::IsInVec<Creators>, AccountId>,
+	>;
 	type Currency = Balances;
 	type Extra = ();
-	type ForceOrigin = EnsureRoot<AccountId>;
+	type ForceOrigin = frame_system::EnsureRoot<AccountId>;
 	type Freezer = ();
 	type MetadataDepositBase = ConstU128<0>;
 	type MetadataDepositPerByte = ConstU128<0>;

--- a/runtime/darwinia/src/pallets/bridge_dispatch.rs
+++ b/runtime/darwinia/src/pallets/bridge_dispatch.rs
@@ -34,7 +34,7 @@ impl bp_message_dispatch::CallValidate<AccountId, RuntimeOrigin, RuntimeCall> fo
 				let total_payment =
 					darwinia_message_transact::total_payment::<Runtime>((&**tx).into());
 				let relayer =
-					pallet_evm::Pallet::<Runtime>::account_basic(&H160(relayer_account.0)).0;
+					pallet_evm::Pallet::<Runtime>::account_basic(&sp_core::H160(relayer_account.0)).0;
 
 				frame_support::ensure!(relayer.balance >= total_payment, "Insufficient balance");
 				Ok(())
@@ -87,7 +87,7 @@ impl bp_message_dispatch::IntoDispatchOrigin<AccountId, RuntimeCall, RuntimeOrig
 		match call {
 			RuntimeCall::MessageTransact(darwinia_message_transact::Call::message_transact {
 				..
-			}) => darwinia_message_transact::LcmpEthOrigin::MessageTransact(H160(id.0)).into(),
+			}) => darwinia_message_transact::LcmpEthOrigin::MessageTransact(sp_core::H160(id.0)).into(),
 			_ => frame_system::RawOrigin::Signed(*id).into(),
 		}
 	}

--- a/runtime/darwinia/src/pallets/dmp_queue.rs
+++ b/runtime/darwinia/src/pallets/dmp_queue.rs
@@ -20,7 +20,7 @@
 use crate::*;
 
 impl cumulus_pallet_dmp_queue::Config for Runtime {
-	type ExecuteOverweightOrigin = EnsureRoot<AccountId>;
+	type ExecuteOverweightOrigin = frame_system::EnsureRoot<AccountId>;
 	type RuntimeEvent = RuntimeEvent;
-	type XcmExecutor = XcmExecutor<XcmExecutorConfig>;
+	type XcmExecutor = xcm_executor::XcmExecutor<XcmExecutorConfig>;
 }

--- a/runtime/darwinia/src/pallets/evm.rs
+++ b/runtime/darwinia/src/pallets/evm.rs
@@ -24,16 +24,16 @@ use pallet_evm::Precompile;
 const WEIGHT_PER_GAS: u64 = 40_000;
 
 frame_support::parameter_types! {
-	pub BlockGasLimit: U256 = U256::from(NORMAL_DISPATCH_RATIO * MAXIMUM_BLOCK_WEIGHT.ref_time() / WEIGHT_PER_GAS);
+	pub BlockGasLimit: sp_core::U256 = sp_core::U256::from(NORMAL_DISPATCH_RATIO * MAXIMUM_BLOCK_WEIGHT.ref_time() / WEIGHT_PER_GAS);
 	pub PrecompilesValue: DarwiniaPrecompiles<Runtime> = DarwiniaPrecompiles::<_>::new();
-	pub WeightPerGas: Weight = Weight::from_ref_time(WEIGHT_PER_GAS);
+	pub WeightPerGas: frame_support::weights::Weight = frame_support::weights::Weight::from_ref_time(WEIGHT_PER_GAS);
 }
 
 pub struct FindAuthorTruncated<F>(sp_std::marker::PhantomData<F>);
-impl<F: frame_support::traits::FindAuthor<u32>> frame_support::traits::FindAuthor<H160>
+impl<F: frame_support::traits::FindAuthor<u32>> frame_support::traits::FindAuthor<sp_core::H160>
 	for FindAuthorTruncated<F>
 {
-	fn find_author<'a, I>(digests: I) -> Option<H160>
+	fn find_author<'a, I>(digests: I) -> Option<sp_core::H160>
 	where
 		I: 'a + IntoIterator<Item = (frame_support::ConsensusEngineId, &'a [u8])>,
 	{
@@ -45,7 +45,7 @@ impl<F: frame_support::traits::FindAuthor<u32>> frame_support::traits::FindAutho
 				let raw = id.to_raw_vec();
 
 				if raw.len() >= 24 {
-					Some(H160::from_slice(&raw[4..24]))
+					Some(sp_core::H160::from_slice(&raw[4..24]))
 				} else {
 					None
 				}
@@ -56,8 +56,8 @@ impl<F: frame_support::traits::FindAuthor<u32>> frame_support::traits::FindAutho
 
 pub struct FixedGasPrice;
 impl pallet_evm::FeeCalculator for FixedGasPrice {
-	fn min_gas_price() -> (U256, Weight) {
-		(U256::from(GWEI), Weight::zero())
+	fn min_gas_price() -> (sp_core::U256, frame_support::weights::Weight) {
+		(sp_core::U256::from(GWEI), frame_support::weights::Weight::zero())
 	}
 }
 
@@ -65,9 +65,9 @@ impl pallet_evm::FeeCalculator for FixedGasPrice {
 pub struct FromH160;
 impl<T> pallet_evm::AddressMapping<T> for FromH160
 where
-	T: From<H160>,
+	T: From<sp_core::H160>,
 {
-	fn into_account_id(address: H160) -> T {
+	fn into_account_id(address: sp_core::H160) -> T {
 		address.into()
 	}
 }
@@ -75,7 +75,7 @@ where
 pub struct AssetIdConverter;
 impl darwinia_precompile_assets::AccountToAssetId<AccountId, AssetId> for AssetIdConverter {
 	fn account_to_asset_id(account_id: AccountId) -> AssetId {
-		let addr: H160 = account_id.into();
+		let addr: sp_core::H160 = account_id.into();
 		addr.to_low_u64_be()
 	}
 }
@@ -90,7 +90,7 @@ where
 		Self(Default::default())
 	}
 
-	pub fn used_addresses() -> [H160; 15] {
+	pub fn used_addresses() -> [sp_core::H160; 15] {
 		[
 			addr(1),
 			addr(2),
@@ -164,7 +164,7 @@ where
 		}
 	}
 
-	fn is_precompile(&self, address: H160) -> bool {
+	fn is_precompile(&self, address: sp_core::H160) -> bool {
 		Self::used_addresses().contains(&address)
 	}
 }
@@ -188,6 +188,6 @@ impl pallet_evm::Config for Runtime {
 	type WithdrawOrigin = pallet_evm::EnsureAddressNever<AccountId>;
 }
 
-fn addr(a: u64) -> H160 {
-	H160::from_low_u64_be(a)
+fn addr(a: u64) -> sp_core::H160 {
+	sp_core::H160::from_low_u64_be(a)
 }

--- a/runtime/darwinia/src/pallets/parachain_system.rs
+++ b/runtime/darwinia/src/pallets/parachain_system.rs
@@ -20,12 +20,12 @@
 use crate::*;
 
 frame_support::parameter_types! {
-	pub const ReservedXcmpWeight: Weight = MAXIMUM_BLOCK_WEIGHT.saturating_div(4);
-	pub const ReservedDmpWeight: Weight = MAXIMUM_BLOCK_WEIGHT.saturating_div(4);
+	pub const ReservedXcmpWeight: frame_support::weights::Weight = MAXIMUM_BLOCK_WEIGHT.saturating_div(4);
+	pub const ReservedDmpWeight: frame_support::weights::Weight = MAXIMUM_BLOCK_WEIGHT.saturating_div(4);
 }
 
 impl cumulus_pallet_parachain_system::Config for Runtime {
-	type CheckAssociatedRelayNumber = RelayNumberStrictlyIncreases;
+	type CheckAssociatedRelayNumber = cumulus_pallet_parachain_system::RelayNumberStrictlyIncreases;
 	type DmpMessageHandler = DmpQueue;
 	type OnSystemEvent = ();
 	type OutboundXcmpMessageSource = XcmpQueue;

--- a/runtime/darwinia/src/pallets/polkadot_xcm.rs
+++ b/runtime/darwinia/src/pallets/polkadot_xcm.rs
@@ -135,7 +135,7 @@ impl xcm_executor::Config for XcmExecutorConfig {
 	type RuntimeCall = RuntimeCall;
 	type SubscriptionService = PolkadotXcm;
 	type Trader = xcm_configs::LocalAssetTrader<
-		ConstantMultiplier<Balance, darwinia_common_runtime::xcm_configs::XcmBaseWeightFee>,
+		frame_support::weights::ConstantMultiplier<Balance, darwinia_common_runtime::xcm_configs::XcmBaseWeightFee>,
 		AnchoringSelfReserve,
 		AccountId,
 		Balances,

--- a/runtime/darwinia/src/pallets/preimage.rs
+++ b/runtime/darwinia/src/pallets/preimage.rs
@@ -23,7 +23,7 @@ impl pallet_preimage::Config for Runtime {
 	type BaseDeposit = ConstU128<{ 500 * UNIT }>;
 	type ByteDeposit = ConstU128<{ darwinia_deposit(0, 1) }>;
 	type Currency = Balances;
-	type ManagerOrigin = EnsureRoot<AccountId>;
+	type ManagerOrigin = frame_system::EnsureRoot<AccountId>;
 	type RuntimeEvent = RuntimeEvent;
 	type WeightInfo = ();
 }

--- a/runtime/darwinia/src/pallets/system.rs
+++ b/runtime/darwinia/src/pallets/system.rs
@@ -21,17 +21,18 @@ use crate::*;
 
 /// We assume that ~5% of the block weight is consumed by `on_initialize` handlers. This is
 /// used to limit the maximal weight of a single extrinsic.
-const AVERAGE_ON_INITIALIZE_RATIO: Perbill = Perbill::from_percent(5);
+const AVERAGE_ON_INITIALIZE_RATIO: sp_runtime::Perbill = sp_runtime::Perbill::from_percent(5);
 
 /// We allow `Normal` extrinsics to fill up the block up to 75%, the rest can be used by
 /// `Operational` extrinsics.
-pub const NORMAL_DISPATCH_RATIO: Perbill = Perbill::from_percent(75);
+pub const NORMAL_DISPATCH_RATIO: sp_runtime::Perbill = sp_runtime::Perbill::from_percent(75);
 
 /// We allow for 0.5 of a second of compute with a 12 second average block time.
-pub const MAXIMUM_BLOCK_WEIGHT: Weight = Weight::from_parts(
-	frame_support::weights::constants::WEIGHT_REF_TIME_PER_SECOND.saturating_div(2),
-	cumulus_primitives_core::relay_chain::v2::MAX_POV_SIZE as u64,
-);
+pub const MAXIMUM_BLOCK_WEIGHT: frame_support::weights::Weight =
+	frame_support::weights::Weight::from_parts(
+		frame_support::weights::constants::WEIGHT_REF_TIME_PER_SECOND.saturating_div(2),
+		cumulus_primitives_core::relay_chain::v2::MAX_POV_SIZE as u64,
+	);
 
 frame_support::parameter_types! {
 	pub const Version: sp_version::RuntimeVersion = VERSION;
@@ -39,13 +40,13 @@ frame_support::parameter_types! {
 		frame_system::limits::BlockLength::max_with_normal_ratio(5 * 1024 * 1024, NORMAL_DISPATCH_RATIO);
 	pub RuntimeBlockWeights: frame_system::limits::BlockWeights = frame_system::limits::BlockWeights::builder()
 		.base_block(weights::BlockExecutionWeight::get())
-		.for_class(DispatchClass::all(), |weights| {
+		.for_class(frame_support::dispatch::DispatchClass::all(), |weights| {
 			weights.base_extrinsic = weights::ExtrinsicBaseWeight::get();
 		})
-		.for_class(DispatchClass::Normal, |weights| {
+		.for_class(frame_support::dispatch::DispatchClass::Normal, |weights| {
 			weights.max_total = Some(NORMAL_DISPATCH_RATIO * MAXIMUM_BLOCK_WEIGHT);
 		})
-		.for_class(DispatchClass::Operational, |weights| {
+		.for_class(frame_support::dispatch::DispatchClass::Operational, |weights| {
 			weights.max_total = Some(MAXIMUM_BLOCK_WEIGHT);
 			// Operational transactions have some extra reserved space, so that they
 			// are included even if block reached `MAXIMUM_BLOCK_WEIGHT`.
@@ -79,7 +80,7 @@ impl frame_system::Config for Runtime {
 	/// The hashing algorithm used.
 	type Hashing = Hashing;
 	/// The header type.
-	type Header = generic::Header<BlockNumber, Self::Hashing>;
+	type Header = sp_runtime::generic::Header<BlockNumber, Self::Hashing>;
 	/// The index type for storing how many extrinsics an account has signed.
 	type Index = Index;
 	/// The lookup mechanism to get account ID from whatever is passed in dispatchers.

--- a/runtime/darwinia/src/pallets/transaction_payment.rs
+++ b/runtime/darwinia/src/pallets/transaction_payment.rs
@@ -22,7 +22,7 @@ use crate::*;
 impl pallet_transaction_payment::Config for Runtime {
 	type FeeMultiplierUpdate = polkadot_runtime_common::SlowAdjustingFeeUpdate<Self>;
 	// Relay Chain `TransactionByteFee` / 10
-	type LengthToFee = ConstantMultiplier<Balance, ConstU128<{ 10 * MICROUNIT }>>;
+	type LengthToFee = frame_support::weights::ConstantMultiplier<Balance, ConstU128<{ 10 * MICROUNIT }>>;
 	type OnChargeTransaction =
 		pallet_transaction_payment::CurrencyAdapter<Balances, DealWithFees<Runtime>>;
 	type OperationalFeeMultiplier = sp_runtime::traits::ConstU8<5>;

--- a/runtime/darwinia/src/pallets/vesting.rs
+++ b/runtime/darwinia/src/pallets/vesting.rs
@@ -20,8 +20,10 @@
 use crate::*;
 
 frame_support::parameter_types! {
-	pub UnvestedFundsAllowedWithdrawReasons: WithdrawReasons =
-		WithdrawReasons::except(WithdrawReasons::TRANSFER | WithdrawReasons::RESERVE);
+	pub UnvestedFundsAllowedWithdrawReasons: frame_support::traits::WithdrawReasons =
+		frame_support::traits::WithdrawReasons::except(
+			frame_support::traits::WithdrawReasons::TRANSFER | frame_support::traits::WithdrawReasons::RESERVE
+		);
 }
 
 impl pallet_vesting::Config for Runtime {

--- a/runtime/darwinia/src/pallets/xcmp_queue.rs
+++ b/runtime/darwinia/src/pallets/xcmp_queue.rs
@@ -21,11 +21,11 @@ use crate::*;
 
 impl cumulus_pallet_xcmp_queue::Config for Runtime {
 	type ChannelInfo = ParachainSystem;
-	type ControllerOrigin = EnsureRoot<AccountId>;
+	type ControllerOrigin = frame_system::EnsureRoot<AccountId>;
 	type ControllerOriginConverter = XcmOriginToTransactDispatchOrigin;
-	type ExecuteOverweightOrigin = EnsureRoot<AccountId>;
+	type ExecuteOverweightOrigin = frame_system::EnsureRoot<AccountId>;
 	type RuntimeEvent = RuntimeEvent;
 	type VersionWrapper = ();
 	type WeightInfo = weights::cumulus_pallet_xcmp_queue::WeightInfo<Self>;
-	type XcmExecutor = XcmExecutor<XcmExecutorConfig>;
+	type XcmExecutor = xcm_executor::XcmExecutor<XcmExecutorConfig>;
 }

--- a/runtime/darwinia/src/weights/block_weights.rs
+++ b/runtime/darwinia/src/weights/block_weights.rs
@@ -16,35 +16,31 @@
 // limitations under the License.
 
 pub mod constants {
-	use frame_support::{
-		parameter_types,
-		weights::{constants, Weight},
-	};
-
-	parameter_types! {
+	frame_support::parameter_types! {
 		/// Importing a block with 0 Extrinsics.
-		pub const BlockExecutionWeight: Weight = Weight::from_ref_time(constants::WEIGHT_REF_TIME_PER_NANOS.saturating_mul(5_000_000));
+		pub const BlockExecutionWeight: frame_support::weights::Weight =
+			frame_support::weights::Weight::from_ref_time(frame_support::weights::constants::WEIGHT_REF_TIME_PER_NANOS.saturating_mul(5_000_000));
 	}
 
 	#[cfg(test)]
 	mod test_weights {
-		use frame_support::weights::constants;
-
 		/// Checks that the weight exists and is sane.
 		// NOTE: If this test fails but you are sure that the generated values are fine,
 		// you can delete it.
 		#[test]
 		fn sane() {
-			let w = super::constants::BlockExecutionWeight::get();
+			let w = frame_support::weights::constants::BlockExecutionWeight::get();
 
 			// At least 100 µs.
 			assert!(
-				w.ref_time() >= 100u64 * constants::WEIGHT_REF_TIME_PER_MICROS,
+				w.ref_time()
+					>= 100u64 * frame_support::weights::constants::WEIGHT_REF_TIME_PER_MICROS,
 				"Weight should be at least 100 µs."
 			);
 			// At most 50 ms.
 			assert!(
-				w.ref_time() <= 50u64 * constants::WEIGHT_REF_TIME_PER_MILLIS,
+				w.ref_time()
+					<= 50u64 * frame_support::weights::constants::WEIGHT_REF_TIME_PER_MILLIS,
 				"Weight should be at most 50 ms."
 			);
 		}

--- a/runtime/darwinia/src/weights/extrinsic_weights.rs
+++ b/runtime/darwinia/src/weights/extrinsic_weights.rs
@@ -16,35 +16,30 @@
 // limitations under the License.
 
 pub mod constants {
-	use frame_support::{
-		parameter_types,
-		weights::{constants, Weight},
-	};
-
-	parameter_types! {
+	frame_support::parameter_types! {
 		/// Executing a NO-OP `System::remarks` Extrinsic.
-		pub const ExtrinsicBaseWeight: Weight = Weight::from_ref_time(constants::WEIGHT_REF_TIME_PER_NANOS.saturating_mul(125_000));
+		pub const ExtrinsicBaseWeight: frame_support::weights::Weight =
+			frame_support::weights::Weight::from_ref_time(frame_support::weights::constants::WEIGHT_REF_TIME_PER_NANOS.saturating_mul(125_000));
 	}
 
 	#[cfg(test)]
 	mod test_weights {
-		use frame_support::weights::constants;
-
 		/// Checks that the weight exists and is sane.
 		// NOTE: If this test fails but you are sure that the generated values are fine,
 		// you can delete it.
 		#[test]
 		fn sane() {
-			let w = super::constants::ExtrinsicBaseWeight::get();
+			let w = frame_support::weights::constants::ExtrinsicBaseWeight::get();
 
 			// At least 10 µs.
 			assert!(
-				w.ref_time() >= 10u64 * constants::WEIGHT_REF_TIME_PER_MICROS,
+				w.ref_time()
+					>= 10u64 * frame_support::weights::constants::WEIGHT_REF_TIME_PER_MICROS,
 				"Weight should be at least 10 µs."
 			);
 			// At most 1 ms.
 			assert!(
-				w.ref_time() <= constants::WEIGHT_REF_TIME_PER_MILLIS,
+				w.ref_time() <= frame_support::weights::constants::WEIGHT_REF_TIME_PER_MILLIS,
 				"Weight should be at most 1 ms."
 			);
 		}

--- a/runtime/pangolin/src/lib.rs
+++ b/runtime/pangolin/src/lib.rs
@@ -33,34 +33,14 @@ pub use darwinia_common_runtime::*;
 pub use dc_primitives::*;
 pub use sp_consensus_aura::sr25519::AuthorityId as AuraId;
 
-// cumulus
-use cumulus_pallet_parachain_system::RelayNumberStrictlyIncreases;
-// polkadot
-use xcm_executor::XcmExecutor;
 // substrate
-use frame_support::{
-	dispatch::DispatchClass,
-	traits::{AsEnsureOriginWithArg, Imbalance, IsInVec, OnUnbalanced, WithdrawReasons},
-	weights::{ConstantMultiplier, Weight},
-};
-use frame_system::{EnsureRoot, EnsureSignedBy};
-use sp_core::{crypto::KeyTypeId, OpaqueMetadata, H160, H256, U256};
-use sp_runtime::{
-	generic,
-	traits::Block as BlockT,
-	transaction_validity::{TransactionSource, TransactionValidity},
-	ApplyExtrinsicResult, Perbill, Permill,
-};
 use sp_std::prelude::*;
-#[cfg(feature = "std")]
-use sp_version::NativeVersion;
-use sp_version::RuntimeVersion;
 
 /// Block type as expected by this runtime.
-pub type Block = generic::Block<Header, UncheckedExtrinsic>;
+pub type Block = sp_runtime::generic::Block<Header, UncheckedExtrinsic>;
 
 /// A Block signed with a Justification
-pub type SignedBlock = generic::SignedBlock<Block>;
+pub type SignedBlock = sp_runtime::generic::SignedBlock<Block>;
 
 /// The SignedExtension to the basic transaction logic.
 pub type SignedExtra = (
@@ -80,7 +60,7 @@ pub type UncheckedExtrinsic =
 
 /// Extrinsic type that has already been checked.
 pub type CheckedExtrinsic =
-	fp_self_contained::CheckedExtrinsic<AccountId, RuntimeCall, SignedExtra, H160>;
+	fp_self_contained::CheckedExtrinsic<AccountId, RuntimeCall, SignedExtra, sp_core::H160>;
 
 /// Executive: handles dispatch to the various modules.
 pub type Executive = frame_executive::Executive<
@@ -97,7 +77,7 @@ pub const DARWINIA_PROPOSAL_REQUIREMENT: Balance = 5000 * UNIT;
 
 /// Runtime version.
 #[sp_version::runtime_version]
-pub const VERSION: RuntimeVersion = RuntimeVersion {
+pub const VERSION: sp_version::RuntimeVersion = sp_version::RuntimeVersion {
 	spec_name: sp_runtime::create_runtime_str!("Pangolin2"),
 	impl_name: sp_runtime::create_runtime_str!("DarwiniaOfficialRust"),
 	authoring_version: 0,
@@ -115,37 +95,48 @@ impl<R> frame_support::traits::OnUnbalanced<pallet_balances::NegativeImbalance<R
 where
 	R: pallet_balances::Config,
 	R: pallet_balances::Config + pallet_treasury::Config,
-	pallet_treasury::Pallet<R>: OnUnbalanced<pallet_balances::NegativeImbalance<R>>,
+	pallet_treasury::Pallet<R>:
+		frame_support::traits::OnUnbalanced<pallet_balances::NegativeImbalance<R>>,
 {
 	// this seems to be called for substrate-based transactions
 	fn on_unbalanceds<B>(
 		mut fees_then_tips: impl Iterator<Item = pallet_balances::NegativeImbalance<R>>,
 	) {
 		if let Some(fees) = fees_then_tips.next() {
+			// substrate
+			use frame_support::traits::Imbalance;
+
 			// for fees, 80% are burned, 20% to the treasury
 			let (_, to_treasury) = fees.ration(80, 20);
 
 			// Balances pallet automatically burns dropped Negative Imbalances by decreasing
 			// total_supply accordingly
-			<pallet_treasury::Pallet<R> as OnUnbalanced<_>>::on_unbalanced(to_treasury);
+			<pallet_treasury::Pallet<R> as frame_support::traits::OnUnbalanced<_>>::on_unbalanced(
+				to_treasury,
+			);
 		}
 	}
 
 	// this is called from pallet_evm for Ethereum-based transactions
 	// (technically, it calls on_unbalanced, which calls this when non-zero)
 	fn on_nonzero_unbalanced(amount: pallet_balances::NegativeImbalance<R>) {
+		// substrate
+		use frame_support::traits::Imbalance;
+
 		// Balances pallet automatically burns dropped Negative Imbalances by decreasing
 		// total_supply accordingly
 		let (_, to_treasury) = amount.ration(80, 20);
 
-		<pallet_treasury::Pallet<R> as OnUnbalanced<_>>::on_unbalanced(to_treasury);
+		<pallet_treasury::Pallet<R> as frame_support::traits::OnUnbalanced<_>>::on_unbalanced(
+			to_treasury,
+		);
 	}
 }
 
 /// The version information used to identify this runtime when compiled natively.
 #[cfg(feature = "std")]
-pub fn native_version() -> NativeVersion {
-	NativeVersion { runtime_version: VERSION, can_author_with: Default::default() }
+pub fn native_version() -> sp_version::NativeVersion {
+	sp_version::NativeVersion { runtime_version: VERSION, can_author_with: Default::default() }
 }
 
 // Create the runtime by composing the FRAME pallets that were previously configured.
@@ -235,7 +226,7 @@ sp_api::impl_runtime_apis! {
 	}
 
 	impl sp_api::Core<Block> for Runtime {
-		fn version() -> RuntimeVersion {
+		fn version() -> sp_version::RuntimeVersion {
 			VERSION
 		}
 
@@ -243,27 +234,27 @@ sp_api::impl_runtime_apis! {
 			Executive::execute_block(block)
 		}
 
-		fn initialize_block(header: &<Block as BlockT>::Header) {
+		fn initialize_block(header: &<Block as sp_runtime::traits::Block>::Header) {
 			Executive::initialize_block(header)
 		}
 	}
 
 	impl sp_api::Metadata<Block> for Runtime {
-		fn metadata() -> OpaqueMetadata {
-			OpaqueMetadata::new(Runtime::metadata().into())
+		fn metadata() -> sp_core::OpaqueMetadata {
+			sp_core::OpaqueMetadata::new(Runtime::metadata().into())
 		}
 	}
 
 	impl sp_block_builder::BlockBuilder<Block> for Runtime {
-		fn apply_extrinsic(extrinsic: <Block as BlockT>::Extrinsic) -> ApplyExtrinsicResult {
+		fn apply_extrinsic(extrinsic: <Block as sp_runtime::traits::Block>::Extrinsic) -> sp_runtime::ApplyExtrinsicResult {
 			Executive::apply_extrinsic(extrinsic)
 		}
 
-		fn finalize_block() -> <Block as BlockT>::Header {
+		fn finalize_block() -> <Block as sp_runtime::traits::Block>::Header {
 			Executive::finalize_block()
 		}
 
-		fn inherent_extrinsics(data: sp_inherents::InherentData) -> Vec<<Block as BlockT>::Extrinsic> {
+		fn inherent_extrinsics(data: sp_inherents::InherentData) -> Vec<<Block as sp_runtime::traits::Block>::Extrinsic> {
 			data.create_extrinsics()
 		}
 
@@ -277,16 +268,16 @@ sp_api::impl_runtime_apis! {
 
 	impl sp_transaction_pool::runtime_api::TaggedTransactionQueue<Block> for Runtime {
 		fn validate_transaction(
-			source: TransactionSource,
-			tx: <Block as BlockT>::Extrinsic,
-			block_hash: <Block as BlockT>::Hash,
-		) -> TransactionValidity {
+			source: sp_runtime::transaction_validity::TransactionSource,
+			tx: <Block as sp_runtime::traits::Block>::Extrinsic,
+			block_hash: <Block as sp_runtime::traits::Block>::Hash,
+		) -> sp_runtime::transaction_validity::TransactionValidity {
 			Executive::validate_transaction(source, tx, block_hash)
 		}
 	}
 
 	impl sp_offchain::OffchainWorkerApi<Block> for Runtime {
-		fn offchain_worker(header: &<Block as BlockT>::Header) {
+		fn offchain_worker(header: &<Block as sp_runtime::traits::Block>::Header) {
 			Executive::offchain_worker(header)
 		}
 	}
@@ -298,7 +289,7 @@ sp_api::impl_runtime_apis! {
 
 		fn decode_session_keys(
 			encoded: Vec<u8>,
-		) -> Option<Vec<(Vec<u8>, KeyTypeId)>> {
+		) -> Option<Vec<(Vec<u8>, sp_runtime::KeyTypeId)>> {
 			SessionKeys::decode_into_raw_public_keys(&encoded)
 		}
 	}
@@ -311,13 +302,13 @@ sp_api::impl_runtime_apis! {
 
 	impl pallet_transaction_payment_rpc_runtime_api::TransactionPaymentApi<Block, Balance> for Runtime {
 		fn query_info(
-			uxt: <Block as BlockT>::Extrinsic,
+			uxt: <Block as sp_runtime::traits::Block>::Extrinsic,
 			len: u32,
 		) -> pallet_transaction_payment_rpc_runtime_api::RuntimeDispatchInfo<Balance> {
 			TransactionPayment::query_info(uxt, len)
 		}
 		fn query_fee_details(
-			uxt: <Block as BlockT>::Extrinsic,
+			uxt: <Block as sp_runtime::traits::Block>::Extrinsic,
 			len: u32,
 		) -> pallet_transaction_payment::FeeDetails<Balance> {
 			TransactionPayment::query_fee_details(uxt, len)
@@ -342,7 +333,7 @@ sp_api::impl_runtime_apis! {
 	}
 
 	impl cumulus_primitives_core::CollectCollationInfo<Block> for Runtime {
-		fn collect_collation_info(header: &<Block as BlockT>::Header) -> cumulus_primitives_core::CollationInfo {
+		fn collect_collation_info(header: &<Block as sp_runtime::traits::Block>::Header) -> cumulus_primitives_core::CollationInfo {
 			ParachainSystem::collect_collation_info(header)
 		}
 	}
@@ -352,13 +343,13 @@ sp_api::impl_runtime_apis! {
 			<<Runtime as pallet_evm::Config>::ChainId as frame_support::traits::Get<u64>>::get()
 		}
 
-		fn account_basic(address: H160) -> pallet_evm::Account {
+		fn account_basic(address: sp_core::H160) -> pallet_evm::Account {
 			let (account, _) = Evm::account_basic(&address);
 
 			account
 		}
 
-		fn gas_price() -> U256 {
+		fn gas_price() -> sp_core::U256 {
 			// frontier
 			use pallet_evm::FeeCalculator;
 
@@ -367,33 +358,33 @@ sp_api::impl_runtime_apis! {
 			gas_price
 		}
 
-		fn account_code_at(address: H160) -> Vec<u8> {
+		fn account_code_at(address: sp_core::H160) -> Vec<u8> {
 			Evm::account_codes(address)
 		}
 
-		fn author() -> H160 {
+		fn author() -> sp_core::H160 {
 			<pallet_evm::Pallet<Runtime>>::find_author()
 		}
 
-		fn storage_at(address: H160, index: U256) -> H256 {
+		fn storage_at(address: sp_core::H160, index: sp_core::U256) -> sp_core::H256 {
 			let mut tmp = [0u8; 32];
 
 			index.to_big_endian(&mut tmp);
 
-			Evm::account_storages(address, H256::from_slice(&tmp[..]))
+			Evm::account_storages(address, sp_core::H256::from_slice(&tmp[..]))
 		}
 
 		fn call(
-			from: H160,
-			to: H160,
+			from: sp_core::H160,
+			to: sp_core::H160,
 			data: Vec<u8>,
-			value: U256,
-			gas_limit: U256,
-			max_fee_per_gas: Option<U256>,
-			max_priority_fee_per_gas: Option<U256>,
-			nonce: Option<U256>,
+			value: sp_core::U256,
+			gas_limit: sp_core::U256,
+			max_fee_per_gas: Option<sp_core::U256>,
+			max_priority_fee_per_gas: Option<sp_core::U256>,
+			nonce: Option<sp_core::U256>,
 			estimate: bool,
-			access_list: Option<Vec<(H160, Vec<H256>)>>,
+			access_list: Option<Vec<(sp_core::H160, Vec<sp_core::H256>)>>,
 		) -> Result<pallet_evm::CallInfo, sp_runtime::DispatchError> {
 			// frontier
 			use pallet_evm::Runner;
@@ -429,15 +420,15 @@ sp_api::impl_runtime_apis! {
 		}
 
 		fn create(
-			from: H160,
+			from: sp_core::H160,
 			data: Vec<u8>,
-			value: U256,
-			gas_limit: U256,
-			max_fee_per_gas: Option<U256>,
-			max_priority_fee_per_gas: Option<U256>,
-			nonce: Option<U256>,
+			value: sp_core::U256,
+			gas_limit: sp_core::U256,
+			max_fee_per_gas: Option<sp_core::U256>,
+			max_priority_fee_per_gas: Option<sp_core::U256>,
+			nonce: Option<sp_core::U256>,
 			estimate: bool,
-			access_list: Option<Vec<(H160, Vec<H256>)>>,
+			access_list: Option<Vec<(sp_core::H160, Vec<sp_core::H256>)>>,
 		) -> Result<pallet_evm::CreateInfo, sp_runtime::DispatchError> {
 			// frontier
 			use pallet_evm::Runner;
@@ -496,7 +487,7 @@ sp_api::impl_runtime_apis! {
 		}
 
 		fn extrinsic_filter(
-			xts: Vec<<Block as BlockT>::Extrinsic>,
+			xts: Vec<<Block as sp_runtime::traits::Block>::Extrinsic>,
 		) -> Vec<pallet_ethereum::Transaction> {
 			xts.into_iter().filter_map(|xt| match xt.0.function {
 				RuntimeCall::Ethereum(
@@ -506,7 +497,7 @@ sp_api::impl_runtime_apis! {
 			}).collect::<Vec<pallet_ethereum::Transaction>>()
 		}
 
-		fn elasticity() -> Option<Permill> {
+		fn elasticity() -> Option<sp_runtime::Permill> {
 			None
 		}
 
@@ -517,7 +508,7 @@ sp_api::impl_runtime_apis! {
 	impl fp_rpc::ConvertTransactionRuntimeApi<Block> for Runtime {
 		fn convert_transaction(
 			transaction: pallet_ethereum::Transaction
-		) -> <Block as BlockT>::Extrinsic {
+		) -> <Block as sp_runtime::traits::Block>::Extrinsic {
 			UncheckedExtrinsic::new_unsigned(
 				pallet_ethereum::Call::<Runtime>::transact { transaction }.into(),
 			)
@@ -583,7 +574,7 @@ sp_api::impl_runtime_apis! {
 
 	#[cfg(feature = "try-runtime")]
 	impl frame_try_runtime::TryRuntime<Block> for Runtime {
-		fn on_runtime_upgrade(checks: bool) -> (Weight, Weight) {
+		fn on_runtime_upgrade(checks: bool) -> (Weight, frame_support::weights::Weight) {
 			// substrate
 			use frame_support::log;
 
@@ -643,9 +634,9 @@ mod tests {
 
 	#[test]
 	fn configured_base_extrinsic_weight_is_evm_compatible() {
-		let min_ethereum_transaction_weight = WeightPerGas::get() * 21_000;
+		let min_ethereum_transaction_weight = frame_support::weights::WeightPerGas::get() * 21_000;
 		let base_extrinsic = <Runtime as frame_system::Config>::BlockWeights::get()
-			.get(DispatchClass::Normal)
+			.get(frame_support::dispatch::DispatchClass::Normal)
 			.base_extrinsic;
 
 		assert!(base_extrinsic.ref_time() <= min_ethereum_transaction_weight.ref_time());

--- a/runtime/pangolin/src/lib.rs
+++ b/runtime/pangolin/src/lib.rs
@@ -628,13 +628,11 @@ cumulus_pallet_parachain_system::register_validate_block! {
 #[cfg(test)]
 mod tests {
 	// darwinia
-	use super::{Runtime, WeightPerGas};
-	// substrate
-	use frame_support::dispatch::DispatchClass;
+	use super::*;
 
 	#[test]
 	fn configured_base_extrinsic_weight_is_evm_compatible() {
-		let min_ethereum_transaction_weight = frame_support::weights::WeightPerGas::get() * 21_000;
+		let min_ethereum_transaction_weight = WeightPerGas::get() * 21_000;
 		let base_extrinsic = <Runtime as frame_system::Config>::BlockWeights::get()
 			.get(frame_support::dispatch::DispatchClass::Normal)
 			.base_extrinsic;

--- a/runtime/pangolin/src/pallets/assets.rs
+++ b/runtime/pangolin/src/pallets/assets.rs
@@ -37,10 +37,12 @@ impl pallet_assets::Config for Runtime {
 	type Balance = Balance;
 	#[cfg(feature = "runtime-benchmarks")]
 	type BenchmarkHelper = ();
-	type CreateOrigin = AsEnsureOriginWithArg<EnsureSignedBy<IsInVec<Creators>, AccountId>>;
+	type CreateOrigin = frame_support::traits::AsEnsureOriginWithArg<
+		frame_system::EnsureSignedBy<frame_support::traits::IsInVec<Creators>, AccountId>,
+	>;
 	type Currency = Balances;
 	type Extra = ();
-	type ForceOrigin = EnsureRoot<AccountId>;
+	type ForceOrigin = frame_system::EnsureRoot<AccountId>;
 	type Freezer = ();
 	type MetadataDepositBase = ConstU128<0>;
 	type MetadataDepositPerByte = ConstU128<0>;

--- a/runtime/pangolin/src/pallets/dmp_queue.rs
+++ b/runtime/pangolin/src/pallets/dmp_queue.rs
@@ -20,7 +20,7 @@
 use crate::*;
 
 impl cumulus_pallet_dmp_queue::Config for Runtime {
-	type ExecuteOverweightOrigin = EnsureRoot<AccountId>;
+	type ExecuteOverweightOrigin = frame_system::EnsureRoot<AccountId>;
 	type RuntimeEvent = RuntimeEvent;
-	type XcmExecutor = XcmExecutor<XcmExecutorConfig>;
+	type XcmExecutor = xcm_executor::XcmExecutor<XcmExecutorConfig>;
 }

--- a/runtime/pangolin/src/pallets/evm.rs
+++ b/runtime/pangolin/src/pallets/evm.rs
@@ -24,16 +24,16 @@ use pallet_evm::Precompile;
 const WEIGHT_PER_GAS: u64 = 40_000;
 
 frame_support::parameter_types! {
-	pub BlockGasLimit: U256 = U256::from(NORMAL_DISPATCH_RATIO * MAXIMUM_BLOCK_WEIGHT.ref_time() / WEIGHT_PER_GAS);
+	pub BlockGasLimit: sp_core::U256 = sp_core::U256::from(NORMAL_DISPATCH_RATIO * MAXIMUM_BLOCK_WEIGHT.ref_time() / WEIGHT_PER_GAS);
 	pub PrecompilesValue: PangolinPrecompiles<Runtime> = PangolinPrecompiles::<_>::new();
-	pub WeightPerGas: Weight = Weight::from_ref_time(WEIGHT_PER_GAS);
+	pub WeightPerGas: frame_support::weights::Weight = frame_support::weights::Weight::from_ref_time(WEIGHT_PER_GAS);
 }
 
 pub struct FindAuthorTruncated<F>(sp_std::marker::PhantomData<F>);
-impl<F: frame_support::traits::FindAuthor<u32>> frame_support::traits::FindAuthor<H160>
+impl<F: frame_support::traits::FindAuthor<u32>> frame_support::traits::FindAuthor<sp_core::H160>
 	for FindAuthorTruncated<F>
 {
-	fn find_author<'a, I>(digests: I) -> Option<H160>
+	fn find_author<'a, I>(digests: I) -> Option<sp_core::H160>
 	where
 		I: 'a + IntoIterator<Item = (frame_support::ConsensusEngineId, &'a [u8])>,
 	{
@@ -45,7 +45,7 @@ impl<F: frame_support::traits::FindAuthor<u32>> frame_support::traits::FindAutho
 				let raw = id.to_raw_vec();
 
 				if raw.len() >= 24 {
-					Some(H160::from_slice(&raw[4..24]))
+					Some(sp_core::H160::from_slice(&raw[4..24]))
 				} else {
 					None
 				}
@@ -56,8 +56,8 @@ impl<F: frame_support::traits::FindAuthor<u32>> frame_support::traits::FindAutho
 
 pub struct FixedGasPrice;
 impl pallet_evm::FeeCalculator for FixedGasPrice {
-	fn min_gas_price() -> (U256, Weight) {
-		(U256::from(GWEI), Weight::zero())
+	fn min_gas_price() -> (sp_core::U256, frame_support::weights::Weight) {
+		(sp_core::U256::from(GWEI), frame_support::weights::Weight::zero())
 	}
 }
 
@@ -65,9 +65,9 @@ impl pallet_evm::FeeCalculator for FixedGasPrice {
 pub struct FromH160;
 impl<T> pallet_evm::AddressMapping<T> for FromH160
 where
-	T: From<H160>,
+	T: From<sp_core::H160>,
 {
-	fn into_account_id(address: H160) -> T {
+	fn into_account_id(address: sp_core::H160) -> T {
 		address.into()
 	}
 }
@@ -75,7 +75,7 @@ where
 pub struct AssetIdConverter;
 impl darwinia_precompile_assets::AccountToAssetId<AccountId, AssetId> for AssetIdConverter {
 	fn account_to_asset_id(account_id: AccountId) -> AssetId {
-		let addr: H160 = account_id.into();
+		let addr: sp_core::H160 = account_id.into();
 		addr.to_low_u64_be()
 	}
 }
@@ -90,7 +90,7 @@ where
 		Self(Default::default())
 	}
 
-	pub fn used_addresses() -> [H160; 15] {
+	pub fn used_addresses() -> [sp_core::H160; 15] {
 		[
 			addr(1),
 			addr(2),
@@ -164,7 +164,7 @@ where
 		}
 	}
 
-	fn is_precompile(&self, address: H160) -> bool {
+	fn is_precompile(&self, address: sp_core::H160) -> bool {
 		Self::used_addresses().contains(&address)
 	}
 }
@@ -188,6 +188,6 @@ impl pallet_evm::Config for Runtime {
 	type WithdrawOrigin = pallet_evm::EnsureAddressNever<AccountId>;
 }
 
-fn addr(a: u64) -> H160 {
-	H160::from_low_u64_be(a)
+fn addr(a: u64) -> sp_core::H160 {
+	sp_core::H160::from_low_u64_be(a)
 }

--- a/runtime/pangolin/src/pallets/parachain_system.rs
+++ b/runtime/pangolin/src/pallets/parachain_system.rs
@@ -20,12 +20,12 @@
 use crate::*;
 
 frame_support::parameter_types! {
-	pub const ReservedXcmpWeight: Weight = MAXIMUM_BLOCK_WEIGHT.saturating_div(4);
-	pub const ReservedDmpWeight: Weight = MAXIMUM_BLOCK_WEIGHT.saturating_div(4);
+	pub const ReservedXcmpWeight: frame_support::weights::Weight = MAXIMUM_BLOCK_WEIGHT.saturating_div(4);
+	pub const ReservedDmpWeight: frame_support::weights::Weight = MAXIMUM_BLOCK_WEIGHT.saturating_div(4);
 }
 
 impl cumulus_pallet_parachain_system::Config for Runtime {
-	type CheckAssociatedRelayNumber = RelayNumberStrictlyIncreases;
+	type CheckAssociatedRelayNumber = cumulus_pallet_parachain_system::RelayNumberStrictlyIncreases;
 	type DmpMessageHandler = DmpQueue;
 	type OnSystemEvent = ();
 	type OutboundXcmpMessageSource = XcmpQueue;

--- a/runtime/pangolin/src/pallets/polkadot_xcm.rs
+++ b/runtime/pangolin/src/pallets/polkadot_xcm.rs
@@ -135,7 +135,7 @@ impl xcm_executor::Config for XcmExecutorConfig {
 	type RuntimeCall = RuntimeCall;
 	type SubscriptionService = PolkadotXcm;
 	type Trader = xcm_configs::LocalAssetTrader<
-		ConstantMultiplier<Balance, darwinia_common_runtime::xcm_configs::XcmBaseWeightFee>,
+		frame_support::weights::ConstantMultiplier<Balance, darwinia_common_runtime::xcm_configs::XcmBaseWeightFee>,
 		AnchoringSelfReserve,
 		AccountId,
 		Balances,

--- a/runtime/pangolin/src/pallets/preimage.rs
+++ b/runtime/pangolin/src/pallets/preimage.rs
@@ -23,7 +23,7 @@ impl pallet_preimage::Config for Runtime {
 	type BaseDeposit = ConstU128<{ 500 * UNIT }>;
 	type ByteDeposit = ConstU128<{ darwinia_deposit(0, 1) }>;
 	type Currency = Balances;
-	type ManagerOrigin = EnsureRoot<AccountId>;
+	type ManagerOrigin = frame_system::EnsureRoot<AccountId>;
 	type RuntimeEvent = RuntimeEvent;
 	type WeightInfo = ();
 }

--- a/runtime/pangolin/src/pallets/system.rs
+++ b/runtime/pangolin/src/pallets/system.rs
@@ -21,17 +21,18 @@ use crate::*;
 
 /// We assume that ~5% of the block weight is consumed by `on_initialize` handlers. This is
 /// used to limit the maximal weight of a single extrinsic.
-const AVERAGE_ON_INITIALIZE_RATIO: Perbill = Perbill::from_percent(5);
+const AVERAGE_ON_INITIALIZE_RATIO: sp_runtime::Perbill = sp_runtime::Perbill::from_percent(5);
 
 /// We allow `Normal` extrinsics to fill up the block up to 75%, the rest can be used by
 /// `Operational` extrinsics.
-pub const NORMAL_DISPATCH_RATIO: Perbill = Perbill::from_percent(75);
+pub const NORMAL_DISPATCH_RATIO: sp_runtime::Perbill = sp_runtime::Perbill::from_percent(75);
 
 /// We allow for 0.5 of a second of compute with a 12 second average block time.
-pub const MAXIMUM_BLOCK_WEIGHT: Weight = Weight::from_parts(
-	frame_support::weights::constants::WEIGHT_REF_TIME_PER_SECOND.saturating_div(2),
-	cumulus_primitives_core::relay_chain::v2::MAX_POV_SIZE as u64,
-);
+pub const MAXIMUM_BLOCK_WEIGHT: frame_support::weights::Weight =
+	frame_support::weights::Weight::from_parts(
+		frame_support::weights::constants::WEIGHT_REF_TIME_PER_SECOND.saturating_div(2),
+		cumulus_primitives_core::relay_chain::v2::MAX_POV_SIZE as u64,
+	);
 
 frame_support::parameter_types! {
 	pub const Version: sp_version::RuntimeVersion = VERSION;
@@ -39,13 +40,13 @@ frame_support::parameter_types! {
 		frame_system::limits::BlockLength::max_with_normal_ratio(5 * 1024 * 1024, NORMAL_DISPATCH_RATIO);
 	pub RuntimeBlockWeights: frame_system::limits::BlockWeights = frame_system::limits::BlockWeights::builder()
 		.base_block(weights::BlockExecutionWeight::get())
-		.for_class(DispatchClass::all(), |weights| {
+		.for_class(frame_support::dispatch::DispatchClass::all(), |weights| {
 			weights.base_extrinsic = weights::ExtrinsicBaseWeight::get();
 		})
-		.for_class(DispatchClass::Normal, |weights| {
+		.for_class(frame_support::dispatch::DispatchClass::Normal, |weights| {
 			weights.max_total = Some(NORMAL_DISPATCH_RATIO * MAXIMUM_BLOCK_WEIGHT);
 		})
-		.for_class(DispatchClass::Operational, |weights| {
+		.for_class(frame_support::dispatch::DispatchClass::Operational, |weights| {
 			weights.max_total = Some(MAXIMUM_BLOCK_WEIGHT);
 			// Operational transactions have some extra reserved space, so that they
 			// are included even if block reached `MAXIMUM_BLOCK_WEIGHT`.
@@ -79,7 +80,7 @@ impl frame_system::Config for Runtime {
 	/// The hashing algorithm used.
 	type Hashing = Hashing;
 	/// The header type.
-	type Header = generic::Header<BlockNumber, Self::Hashing>;
+	type Header = sp_runtime::generic::Header<BlockNumber, Self::Hashing>;
 	/// The index type for storing how many extrinsics an account has signed.
 	type Index = Index;
 	/// The lookup mechanism to get account ID from whatever is passed in dispatchers.

--- a/runtime/pangolin/src/pallets/transaction_payment.rs
+++ b/runtime/pangolin/src/pallets/transaction_payment.rs
@@ -22,7 +22,7 @@ use crate::*;
 impl pallet_transaction_payment::Config for Runtime {
 	type FeeMultiplierUpdate = polkadot_runtime_common::SlowAdjustingFeeUpdate<Self>;
 	// Relay Chain `TransactionByteFee` / 10
-	type LengthToFee = ConstantMultiplier<Balance, ConstU128<{ 10 * MICROUNIT }>>;
+	type LengthToFee = frame_support::weights::ConstantMultiplier<Balance, ConstU128<{ 10 * MICROUNIT }>>;
 	type OnChargeTransaction =
 		pallet_transaction_payment::CurrencyAdapter<Balances, DealWithFees<Runtime>>;
 	type OperationalFeeMultiplier = sp_runtime::traits::ConstU8<5>;

--- a/runtime/pangolin/src/pallets/vesting.rs
+++ b/runtime/pangolin/src/pallets/vesting.rs
@@ -20,8 +20,10 @@
 use crate::*;
 
 frame_support::parameter_types! {
-	pub UnvestedFundsAllowedWithdrawReasons: WithdrawReasons =
-		WithdrawReasons::except(WithdrawReasons::TRANSFER | WithdrawReasons::RESERVE);
+	pub UnvestedFundsAllowedWithdrawReasons: frame_support::traits::WithdrawReasons =
+		frame_support::traits::WithdrawReasons::except(
+			frame_support::traits::WithdrawReasons::TRANSFER | frame_support::traits::WithdrawReasons::RESERVE
+		);
 }
 
 impl pallet_vesting::Config for Runtime {

--- a/runtime/pangolin/src/pallets/xcmp_queue.rs
+++ b/runtime/pangolin/src/pallets/xcmp_queue.rs
@@ -21,11 +21,11 @@ use crate::*;
 
 impl cumulus_pallet_xcmp_queue::Config for Runtime {
 	type ChannelInfo = ParachainSystem;
-	type ControllerOrigin = EnsureRoot<AccountId>;
+	type ControllerOrigin = frame_system::EnsureRoot<AccountId>;
 	type ControllerOriginConverter = XcmOriginToTransactDispatchOrigin;
-	type ExecuteOverweightOrigin = EnsureRoot<AccountId>;
+	type ExecuteOverweightOrigin = frame_system::EnsureRoot<AccountId>;
 	type RuntimeEvent = RuntimeEvent;
 	type VersionWrapper = ();
 	type WeightInfo = weights::cumulus_pallet_xcmp_queue::WeightInfo<Self>;
-	type XcmExecutor = XcmExecutor<XcmExecutorConfig>;
+	type XcmExecutor = xcm_executor::XcmExecutor<XcmExecutorConfig>;
 }

--- a/runtime/pangolin/src/weights/block_weights.rs
+++ b/runtime/pangolin/src/weights/block_weights.rs
@@ -16,35 +16,31 @@
 // limitations under the License.
 
 pub mod constants {
-	use frame_support::{
-		parameter_types,
-		weights::{constants, Weight},
-	};
-
-	parameter_types! {
+	frame_support::parameter_types! {
 		/// Importing a block with 0 Extrinsics.
-		pub const BlockExecutionWeight: Weight = Weight::from_ref_time(constants::WEIGHT_REF_TIME_PER_NANOS.saturating_mul(5_000_000));
+		pub const BlockExecutionWeight: frame_support::weights::Weight =
+			frame_support::weights::Weight::from_ref_time(frame_support::weights::constants::WEIGHT_REF_TIME_PER_NANOS.saturating_mul(5_000_000));
 	}
 
 	#[cfg(test)]
 	mod test_weights {
-		use frame_support::weights::constants;
-
 		/// Checks that the weight exists and is sane.
 		// NOTE: If this test fails but you are sure that the generated values are fine,
 		// you can delete it.
 		#[test]
 		fn sane() {
-			let w = super::constants::BlockExecutionWeight::get();
+			let w = frame_support::weights::constants::BlockExecutionWeight::get();
 
 			// At least 100 µs.
 			assert!(
-				w.ref_time() >= 100u64 * constants::WEIGHT_REF_TIME_PER_MICROS,
+				w.ref_time()
+					>= 100u64 * frame_support::weights::constants::WEIGHT_REF_TIME_PER_MICROS,
 				"Weight should be at least 100 µs."
 			);
 			// At most 50 ms.
 			assert!(
-				w.ref_time() <= 50u64 * constants::WEIGHT_REF_TIME_PER_MILLIS,
+				w.ref_time()
+					<= 50u64 * frame_support::weights::constants::WEIGHT_REF_TIME_PER_MILLIS,
 				"Weight should be at most 50 ms."
 			);
 		}

--- a/runtime/pangolin/src/weights/extrinsic_weights.rs
+++ b/runtime/pangolin/src/weights/extrinsic_weights.rs
@@ -16,35 +16,30 @@
 // limitations under the License.
 
 pub mod constants {
-	use frame_support::{
-		parameter_types,
-		weights::{constants, Weight},
-	};
-
-	parameter_types! {
+	frame_support::parameter_types! {
 		/// Executing a NO-OP `System::remarks` Extrinsic.
-		pub const ExtrinsicBaseWeight: Weight = Weight::from_ref_time(constants::WEIGHT_REF_TIME_PER_NANOS.saturating_mul(125_000));
+		pub const ExtrinsicBaseWeight: frame_support::weights::Weight =
+			frame_support::weights::Weight::from_ref_time(frame_support::weights::constants::WEIGHT_REF_TIME_PER_NANOS.saturating_mul(125_000));
 	}
 
 	#[cfg(test)]
 	mod test_weights {
-		use frame_support::weights::constants;
-
 		/// Checks that the weight exists and is sane.
 		// NOTE: If this test fails but you are sure that the generated values are fine,
 		// you can delete it.
 		#[test]
 		fn sane() {
-			let w = super::constants::ExtrinsicBaseWeight::get();
+			let w = frame_support::weights::constants::ExtrinsicBaseWeight::get();
 
 			// At least 10 µs.
 			assert!(
-				w.ref_time() >= 10u64 * constants::WEIGHT_REF_TIME_PER_MICROS,
+				w.ref_time()
+					>= 10u64 * frame_support::weights::constants::WEIGHT_REF_TIME_PER_MICROS,
 				"Weight should be at least 10 µs."
 			);
 			// At most 1 ms.
 			assert!(
-				w.ref_time() <= constants::WEIGHT_REF_TIME_PER_MILLIS,
+				w.ref_time() <= frame_support::weights::constants::WEIGHT_REF_TIME_PER_MILLIS,
 				"Weight should be at most 1 ms."
 			);
 		}


### PR DESCRIPTION
Resolve the issues that were introduced in #213.

The goal is avoiding importing pollution and make testing easier (copy and paste the code to mock.rs directly without any modification).