### PR TITLE
Fix broken CI

### DIFF
--- a/tests/ethereum/test-balance.ts
+++ b/tests/ethereum/test-balance.ts
@@ -2,19 +2,18 @@ import Web3 from "web3";
 import { describe } from "mocha";
 import { step } from "mocha-steps";
 import { expect } from "chai";
-import { HOST_HTTP_URL, FAITH, FAITH_P } from "../config";
+import { HOST_HTTP_URL, FAITH, FAITH_P, ALITH } from "../config";
 
 const web3 = new Web3(HOST_HTTP_URL);
 describe("Test balances", () => {
 	const VALUE = "0x200";
-	const TO = "0x1111111111111111111111111111111111111111";
 	const GAS_PRICE = "0x3B9ACA00"; // 1000000000
 
 	let init_from;
 	let init_to;
 	step("Account has correct balance", async function () {
 		init_from = await web3.eth.getBalance(FAITH);
-		init_to = await web3.eth.getBalance(TO);
+		init_to = await web3.eth.getBalance(ALITH);
 
 		expect(Number(init_from)).to.be.greaterThan(Number(VALUE));
 	});
@@ -23,7 +22,7 @@ describe("Test balances", () => {
 		let tx = await web3.eth.accounts.signTransaction(
 			{
 				from: FAITH,
-				to: TO,
+				to: ALITH,
 				value: VALUE,
 				gasPrice: GAS_PRICE,
 				gas: "0x100000",
@@ -42,6 +41,6 @@ describe("Test balances", () => {
 		const expectedToBalance = (BigInt(init_to) + BigInt(VALUE)).toString();
 
 		expect(await web3.eth.getBalance(FAITH)).to.equal(expectedFromBalance);
-		expect(await web3.eth.getBalance(TO)).to.equal(expectedToBalance);
+		expect(await web3.eth.getBalance(ALITH)).to.equal(expectedToBalance);
 	});
 });

--- a/tests/ethereum/test-balance.ts
+++ b/tests/ethereum/test-balance.ts
@@ -12,7 +12,7 @@ describe("Test balances", () => {
 
 	let init_from;
 	let init_to;
-	it("Account has correct balance", async function () {
+	step("Account has correct balance", async function () {
 		init_from = await web3.eth.getBalance(FAITH);
 		init_to = await web3.eth.getBalance(TO);
 


### PR DESCRIPTION
#294 updated the node compilation strategy to build with `--all-features`, that include `run-benchmark`. Under this feature, the ED is 1 instead of 0. This is the root cause. It's easy to fix it by changing to the transfer destination address to an existing account.